### PR TITLE
`bpf-builder` to use `golang:1.20-bullseye` to use the right version of `libbpf`

### DIFF
--- a/bpf-builder/Dockerfile
+++ b/bpf-builder/Dockerfile
@@ -1,5 +1,14 @@
-FROM golang:1.20-alpine
+FROM golang:1.20-bullseye
 
-RUN apk --no-cache update && apk --no-cache add clang llvm libbpf-dev linux-headers
+ENV CGO_ENABLED=1 GOOS=linux
+RUN apt-get update
+RUN apt-get install -y -q \
+    build-essential \
+    binutils-gold \
+    bash \
+    clang \
+    llvm \
+    libbpf-dev 
+
 
 WORKDIR /kubeshark


### PR DESCRIPTION
The build fails with alpine, because libbpf headers do not have the bpf_map_def