### PR TITLE
hostmode initial implementation

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	_ "net/http/pprof" // Blank import to pprof
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/kubeshark/tracer/misc"
@@ -17,12 +19,19 @@ import (
 // capture
 var procfs = flag.String("procfs", "/proc", "The procfs directory, used when mapping host volumes into a container")
 
-// development
-var debug = flag.Bool("debug", false, "Enable debug mode")
-
 var tracer *Tracer
 
 func main() {
+	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" || os.Getenv("KUBERNETES_SERVICE_PORT") == "" {
+		mainHost()
+	} else {
+		mainK8S()
+	}
+}
+
+func mainK8S() {
+	// development
+	var debug = flag.Bool("debug", false, "Enable debug mode")
 	flag.Parse()
 
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
@@ -34,10 +43,38 @@ func main() {
 
 	misc.InitDataDir()
 
-	run()
+	runK8S()
 }
 
-func run() {
+func mainHost() {
+	var err error
+	var cmdLine = flag.String("cmdline", "", "binary command line to handle")
+	var pcapFile = flag.String("pcap", "", "pcap file save into")
+	// development
+	var debug = flag.Bool("debug", false, "Enable debug mode")
+
+	flag.Parse()
+
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).With().Caller().Logger()
+
+	if *debug {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
+
+	misc.InitDataDir()
+
+	var cmdLineRegex *regexp.Regexp
+	if *cmdLine != "" {
+		if cmdLineRegex, err = regexp.Compile(fmt.Sprintf(".*%v.*", *cmdLine)); err != nil {
+			log.Error().Err(err).Send()
+			return
+		}
+	}
+	runHost(cmdLineRegex, *pcapFile)
+}
+
+func runK8S() {
 	log.Info().Msg("Starting tracer...")
 
 	misc.RunID = time.Now().Unix()
@@ -54,6 +91,21 @@ func run() {
 	watcher.Start(ctx, clusterMode)
 
 	go tracer.PollForLogging()
+	tracer.Poll(streamsMap)
+}
+
+func runHost(cmdLineRegex *regexp.Regexp, pcapFile string) {
+	log.Info().Msg("Starting tracer...")
+
+	misc.RunID = time.Now().Unix()
+
+	streamsMap := NewTcpStreamMap()
+
+	NewPacketConsumer(pcapFile)
+
+	createTracerHost(streamsMap, cmdLineRegex)
+
+	go func() {}()
 	tracer.Poll(streamsMap)
 }
 
@@ -75,6 +127,46 @@ func createTracer(streamsMap *TcpStreamMap) {
 
 	podList := kubernetes.GetTargetedPods()
 	if err := UpdateTargets(podList); err != nil {
+		log.Error().Err(err).Send()
+		return
+	}
+
+	// A quick way to instrument libssl.so without PID filtering - used for debuging and troubleshooting
+	//
+	if os.Getenv("KUBESHARK_GLOBAL_LIBSSL_PID") != "" {
+		if err := tracer.GlobalSSLLibTarget(*procfs, os.Getenv("KUBESHARK_GLOBAL_LIBSSL_PID")); err != nil {
+			LogError(err)
+			return
+		}
+	}
+
+	// A quick way to instrument Go `crypto/tls` without PID filtering - used for debuging and troubleshooting
+	//
+	if os.Getenv("KUBESHARK_GLOBAL_GOLANG_PID") != "" {
+		if err := tracer.GlobalGoTarget(*procfs, os.Getenv("KUBESHARK_GLOBAL_GOLANG_PID")); err != nil {
+			LogError(err)
+			return
+		}
+	}
+}
+
+func createTracerHost(streamsMap *TcpStreamMap, cmdLineRegex *regexp.Regexp) {
+	tracer = &Tracer{
+		procfs: *procfs,
+	}
+	chunksBufferSize := os.Getpagesize() * 100
+	logBufferSize := os.Getpagesize()
+
+	if err := tracer.Init(
+		chunksBufferSize,
+		logBufferSize,
+		*procfs,
+	); err != nil {
+		LogError(err)
+		return
+	}
+
+	if err := UpdateTargetsHost(cmdLineRegex); err != nil {
 		log.Error().Err(err).Send()
 		return
 	}

--- a/misc/fs.go
+++ b/misc/fs.go
@@ -1,0 +1,23 @@
+package misc
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func GetProcCmdLine(pid string) (string, error) {
+	file, err := os.Open(filepath.Join("/proc", pid, "cmdline"))
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	buf := make([]byte, 128)
+	_, err = file.Read(buf)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	return string(buf), nil
+}

--- a/packet_consumer.go
+++ b/packet_consumer.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/kubeshark/tracer/misc"
+	"github.com/rs/zerolog/log"
+)
+
+type PacketConsumer struct {
+}
+
+func NewPacketConsumer(pcapFile string) *PacketConsumer {
+	pc := PacketConsumer{}
+	masterPcap := misc.GetMasterPcapPath()
+
+	var err error
+	var pcapHandle *os.File
+
+	if pcapFile != "" {
+		if pcapHandle, err = os.OpenFile(pcapFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644); err != nil {
+			log.Error().Err(err).Msg("Couldn't open pcap for writing:")
+			return nil
+		}
+	}
+
+	if err = os.Remove(masterPcap); err != nil {
+		log.Error().Err(err).Msg("Couldn't remove master pcap:")
+	}
+
+	go pc.consumePackets(masterPcap, pcapHandle)
+
+	return &pc
+}
+
+func (pc *PacketConsumer) consumePackets(pcapName string, pcapHandle *os.File) {
+	select {
+	case <-time.After(1 * time.Second):
+		_, err := os.Stat(misc.GetMasterPcapPath())
+		if err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			log.Error().Err(err).Msg("Couldn't locate pcap:")
+			return
+		}
+	}
+
+	if pcapHandle != nil {
+		defer pcapHandle.Close()
+	}
+
+	file, err := os.OpenFile(misc.GetMasterPcapPath(), os.O_RDONLY, 0)
+	if err != nil {
+		log.Error().Err(err).Msg("Couldn't open master pcap:")
+	} else {
+		var total int
+		for {
+			buf := make([]byte, 1024)
+			n, err := file.Read(buf)
+			if err != nil && err != io.EOF {
+				log.Error().Err(err).Msg("Couldn't read master pcap:")
+				return
+			}
+			total += n
+			if pcapHandle != nil {
+				if _, err = pcapHandle.Write(buf[0:n]); err != nil {
+					log.Error().Err(err).Msg("Couldn't write pcap:")
+					return
+				}
+			}
+			if err == io.EOF {
+				log.Info().Msg(fmt.Sprintf("Read master pcap complete. Total: %v bytes", total))
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
this change makes tracer able two work both kubernetes and non-kubernetes environment. It automatically detects environment based on env variables
It has also to new command line parameters for host mode:
`-cmdline` to filter watching applications based on command line 
`-pcap` - to write intercepted data into given pcap file