### PR TITLE
Do not write pcap header to the named pipe.

### DIFF
--- a/packet_sorter.go
+++ b/packet_sorter.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/kubeshark/gopacket"
-	"github.com/kubeshark/gopacket/layers"
 	"github.com/kubeshark/gopacket/pcapgo"
 	"github.com/kubeshark/tracer/misc"
 	"github.com/rs/zerolog/log"
@@ -66,10 +65,8 @@ func (s *PacketSorter) initMasterPcap() {
 				file:   file,
 				writer: writer,
 			}
-			err = writer.WriteFileHeader(uint32(misc.Snaplen), layers.LinkTypeEthernet)
-			if err != nil {
-				log.Error().Err(err).Msg("While writing the PCAP header:")
-			}
+			// Do not write PCAP header. This is a named pipe, and a worker
+			// might be waiting to read from it already
 		}
 	} else {
 		file, err = os.OpenFile(misc.GetMasterPcapPath(), os.O_APPEND|os.O_WRONLY, os.ModeNamedPipe)


### PR DESCRIPTION
This is to make worker start reading packets from an existing pcap file.