### PR TITLE
last N packets circular buffer: initial implementation

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,11 +15,16 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	globCbufMax = 10_000
+)
+
 // capture
 var procfs = flag.String("procfs", "/proc", "The procfs directory, used when mapping host volumes into a container")
 
 // development
 var debug = flag.Bool("debug", false, "Enable debug mode")
+var globCbuf = flag.Int("cbuf", 0, fmt.Sprintf("Keep last N packets in circular buffer 0 means disabled, max value is %v", globCbufMax))
 
 var tracer *Tracer
 

--- a/misc/data.go
+++ b/misc/data.go
@@ -29,3 +29,7 @@ func SetDataDir(v string) {
 func GetMasterPcapPath() string {
 	return fmt.Sprintf("%s/tls.pcap", GetDataDir())
 }
+
+func GetCbufPcapPath() string {
+	return fmt.Sprintf("%s/tls_last.pcap", GetDataDir())
+}

--- a/packet_cbuf.go
+++ b/packet_cbuf.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/kubeshark/gopacket"
+	"github.com/kubeshark/gopacket/layers"
+	"github.com/kubeshark/gopacket/pcapgo"
+	"github.com/kubeshark/tracer/misc"
+	"github.com/rs/zerolog/log"
+)
+
+type CbufPcap struct {
+	writer *cbufWriter
+}
+
+func NewCbufPcap(cbufSize int) *CbufPcap {
+	p := &CbufPcap{
+		writer: newCbufWriter(cbufSize),
+	}
+	return p
+}
+
+func (c *CbufPcap) WritePacket(ci gopacket.CaptureInfo, data []byte) {
+	c.writer.writePacket(ci, data)
+}
+
+func (c *CbufPcap) DumptoPcapFile(file *os.File, packetsLimit int) (err error) {
+	return c.writer.dumpPacketsPcap(file, packetsLimit)
+}
+
+type cbufPacket struct {
+	ci   gopacket.CaptureInfo
+	data []byte
+}
+
+type cbufWriter struct {
+	counter int
+	pos     int
+	size    int
+	cbuf    map[int]cbufPacket
+	sync.Mutex
+}
+
+func newCbufWriter(size int) *cbufWriter {
+	if size < 1 {
+		return nil
+	}
+	return &cbufWriter{
+		size: size,
+		cbuf: make(map[int]cbufPacket, size),
+	}
+}
+
+func (c *cbufWriter) writePacket(ci gopacket.CaptureInfo, data []byte) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.cbuf[c.pos] = cbufPacket{
+		ci:   ci,
+		data: data,
+	}
+
+	if c.counter < c.size {
+		c.counter++
+	}
+
+	c.pos++
+	if c.pos == c.size {
+		c.pos = 0
+	}
+}
+
+// dumpPacketsPcap dumps max maxCount packets from ringbuf to file writer
+func (c *cbufWriter) dumpPacketsPcap(file *os.File, count int) error {
+	if count < 0 {
+		return errors.New("count less than 0")
+	}
+	writer := pcapgo.NewWriter(file)
+	err := writer.WriteFileHeader(uint32(misc.Snaplen), layers.LinkTypeEthernet)
+	if err != nil {
+		return fmt.Errorf("writing the PCAP header failed: %v", err)
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	if c.counter < count {
+		count = c.counter
+	}
+
+	// c.pos points on the next after last
+	pos := c.pos - count
+	if pos < 0 {
+		pos += c.size
+	}
+
+	for count != 0 {
+		err = writer.WritePacket(c.cbuf[pos].ci, c.cbuf[pos].data)
+		if err != nil {
+			return err
+		}
+		pos++
+		if pos == c.size {
+			pos = 0
+		}
+		count--
+	}
+
+	return nil
+}

--- a/packet_cbuf.go
+++ b/packet_cbuf.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kubeshark/gopacket/layers"
 	"github.com/kubeshark/gopacket/pcapgo"
 	"github.com/kubeshark/tracer/misc"
-	"github.com/rs/zerolog/log"
 )
 
 type CbufPcap struct {

--- a/packet_sorter.go
+++ b/packet_sorter.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/kubeshark/gopacket"
 	"github.com/kubeshark/gopacket/layers"
@@ -33,6 +35,7 @@ func (m *MasterPcap) WritePacket(ci gopacket.CaptureInfo, data []byte) (err erro
 
 type PacketSorter struct {
 	masterPcap    *MasterPcap
+	cbufPcap      *CbufPcap
 	sortedPackets chan<- *SortedPacket
 }
 
@@ -44,6 +47,7 @@ func NewPacketSorter(
 	}
 
 	s.initMasterPcap()
+	s.initCbufPcap()
 
 	return s
 }
@@ -85,8 +89,49 @@ func (s *PacketSorter) initMasterPcap() {
 	}
 }
 
+func (s *PacketSorter) initCbufPcap() {
+	if *globCbuf == 0 {
+		return
+	}
+	if *globCbuf < 0 || *globCbuf > globCbufMax {
+		log.Error().Msg(fmt.Sprintf("Circullar buffer size can not be greater than %v", globCbufMax))
+		return
+	}
+
+	if _, err := os.Stat(misc.GetCbufPcapPath()); errors.Is(err, os.ErrNotExist) {
+		err = syscall.Mkfifo(misc.GetCbufPcapPath(), 0666)
+		if err != nil {
+			log.Error().Err(err).Msg("Couldn't create the named pipe:")
+		}
+	}
+
+	s.cbufPcap = NewCbufPcap(*globCbuf)
+
+	go func() {
+		for {
+			file, err := os.OpenFile(misc.GetCbufPcapPath(), os.O_APPEND|os.O_WRONLY, os.ModeNamedPipe)
+			if err != nil {
+				log.Error().Err(err).Msg("Couldn't create cbuf PCAP:")
+				break
+			}
+			err = s.cbufPcap.DumptoPcapFile(file, *globCbuf)
+			if err != nil {
+				log.Error().Err(err).Msg("Couldn't dump cbuf PCAP:")
+			}
+			file.Close()
+			// wait read side to close the file
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+}
+
 func (s *PacketSorter) getMasterPcap() *MasterPcap {
 	return s.masterPcap
+}
+
+func (s *PacketSorter) getCbufPcap() *CbufPcap {
+	return s.cbufPcap
 }
 
 func (s *PacketSorter) Close() {

--- a/tls_stream.go
+++ b/tls_stream.go
@@ -122,6 +122,12 @@ func (t *tlsStream) writePacket(firstLayerType gopacket.LayerType, l ...gopacket
 	err = t.poller.sorter.getMasterPcap().WritePacket(info, data)
 	if err != nil {
 		log.Error().Err(err).Msg("Error writing PCAP:")
+		return
+	}
+
+	cb := t.poller.sorter.getCbufPcap()
+	if cb != nil {
+		cb.WritePacket(info, data)
 	}
 }
 


### PR DESCRIPTION
For advanced tracer debug a new command line parameter is introduced:

```
  -cbuf int
    	Keep last N packets in circular buffer 0 means disabled, max value is 10000
```

When it is not zero, tracer keeps last 0 < N <=10000 packets in memory and creates `tls_last.pcap` pipe in data directory
Once reading this pipe is requested, tracer writes up to given N packets and closes the pipe

This functionality supposes to clarify https://github.com/kubeshark/tracer/issues/22 