### PR TITLE
Add cgroups V2 support; update kubeshark/ebpf to latest cilium ebpf

### DIFF
--- a/bpf_logger.go
+++ b/bpf_logger.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cilium/ebpf/perf"
 	"github.com/go-errors/errors"
-	"github.com/kubeshark/ebpf/perf"
 	"github.com/rs/zerolog/log"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.19
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/cilium/ebpf v0.12.3
 	github.com/go-errors/errors v1.4.2
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/knightsc/gapstone v0.0.0-20191231144527-6fa5afaf11a9
-	github.com/kubeshark/ebpf v0.9.1
 	github.com/kubeshark/gopacket v1.1.21
 	github.com/kubeshark/tracerproto v0.0.0-20240202162346-06f7e6156851
 	github.com/moby/moby v20.10.17+incompatible
@@ -39,9 +39,10 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
-	golang.org/x/sys v0.6.0 // indirect
+	golang.org/x/sys v0.14.1-0.20231108175955-e4099bfacb8c // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cilium/ebpf v0.12.3 h1:8ht6F9MquybnY97at+VDZb3eQQr8ev79RueWeVaEcG4=
+github.com/cilium/ebpf v0.12.3/go.mod h1:TctK1ivibvI3znr66ljgi4hqOT8EYQjz1KWBfb1UVgM=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
@@ -53,7 +55,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
+github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -150,13 +152,11 @@ github.com/knightsc/gapstone v0.0.0-20191231144527-6fa5afaf11a9/go.mod h1:1K5hEz
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubeshark/ebpf v0.9.1 h1:6EpmXCNMlugeJ5mljpulO7Y8q3txBhBQDlByCTAJcSU=
-github.com/kubeshark/ebpf v0.9.1/go.mod h1:xa2dkwd6OlbgM19yrc+Qd6YPk7dwyfICFOYjjusreyY=
 github.com/kubeshark/gopacket v1.1.21 h1:FP3ZZUxCOL+A8HbrogOR099S5ftLKNZHwqtO6Y0BwsU=
 github.com/kubeshark/gopacket v1.1.21/go.mod h1:rsLQIdGlojc26czarVH2HYFarYEZKMTctVbTwadQ7ts=
 github.com/kubeshark/tracerproto v0.0.0-20240202162346-06f7e6156851 h1:uSH8JsoTg369WsOb/3D/LH1O4l2rDQ3M77tS5mQc3lE=
@@ -229,6 +229,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -328,8 +330,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.1-0.20231108175955-e4099bfacb8c h1:3kC/TjQ+xzIblQv39bCOyRk8fbEeJcDHwbyxPUU2BpA=
+golang.org/x/sys v0.14.1-0.20231108175955-e4099bfacb8c/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=

--- a/go_hooks.go
+++ b/go_hooks.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/cilium/ebpf/link"
 	"github.com/go-errors/errors"
-	"github.com/kubeshark/ebpf/link"
 )
 
 type goHooks struct {
@@ -57,7 +57,7 @@ func (s *goHooks) installHooks(bpfObjects *tracerObjects, ex *link.Executable, o
 	// Symbol points to
 	// [`crypto/tls.(*Conn).Write`](https://github.com/golang/go/blob/go1.17.6/src/crypto/tls/conn.go#L1099)
 	s.goWriteProbe, err = ex.Uprobe(goWriteSymbol, goCryptoTlsWrite, &link.UprobeOptions{
-		Offset: offsets.GoWriteOffset.enter,
+		Address: offsets.GoWriteOffset.enter,
 	})
 
 	if err != nil {
@@ -66,7 +66,7 @@ func (s *goHooks) installHooks(bpfObjects *tracerObjects, ex *link.Executable, o
 
 	for _, offset := range offsets.GoWriteOffset.exits {
 		probe, err := ex.Uprobe(goWriteSymbol, goCryptoTlsWriteEx, &link.UprobeOptions{
-			Offset: offset,
+			Address: offset,
 		})
 
 		if err != nil {
@@ -79,7 +79,7 @@ func (s *goHooks) installHooks(bpfObjects *tracerObjects, ex *link.Executable, o
 	// Symbol points to
 	// [`crypto/tls.(*Conn).Read`](https://github.com/golang/go/blob/go1.17.6/src/crypto/tls/conn.go#L1263)
 	s.goReadProbe, err = ex.Uprobe(goReadSymbol, goCryptoTlsRead, &link.UprobeOptions{
-		Offset: offsets.GoReadOffset.enter,
+		Address: offsets.GoReadOffset.enter,
 	})
 
 	if err != nil {
@@ -88,7 +88,7 @@ func (s *goHooks) installHooks(bpfObjects *tracerObjects, ex *link.Executable, o
 
 	for _, offset := range offsets.GoReadOffset.exits {
 		probe, err := ex.Uprobe(goReadSymbol, goCryptoTlsReadEx, &link.UprobeOptions{
-			Offset: offset,
+			Address: offset,
 		})
 
 		if err != nil {

--- a/go_offsets.go
+++ b/go_offsets.go
@@ -4,15 +4,15 @@ import (
 	"bufio"
 	"debug/dwarf"
 	"debug/elf"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"runtime"
-	"errors"
 
 	"github.com/Masterminds/semver"
+	"github.com/cilium/ebpf/link"
 	"github.com/knightsc/gapstone"
-	"github.com/kubeshark/ebpf/link"
 	"github.com/rs/zerolog/log"
 )
 

--- a/ssllib_hooks.go
+++ b/ssllib_hooks.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/cilium/ebpf/link"
 	"github.com/go-errors/errors"
-	"github.com/kubeshark/ebpf/link"
 )
 
 type sslHooks struct {

--- a/syscall_hooks.go
+++ b/syscall_hooks.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/cilium/ebpf/link"
 	"github.com/go-errors/errors"
-	"github.com/kubeshark/ebpf/link"
 )
 
 type syscallHooks struct {

--- a/tcp_kprobe_hooks.go
+++ b/tcp_kprobe_hooks.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"github.com/cilium/ebpf/link"
 	"github.com/go-errors/errors"
-	"github.com/kubeshark/ebpf/link"
 )
 
 type tcpKprobeHooks struct {

--- a/tls_poller.go
+++ b/tls_poller.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/cilium/ebpf/perf"
 	"github.com/go-errors/errors"
 	"github.com/hashicorp/golang-lru/simplelru"
-	"github.com/kubeshark/ebpf/perf"
 	"github.com/kubeshark/tracer/misc"
 	"github.com/rs/zerolog/log"
 )

--- a/tracer.go
+++ b/tracer.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/cilium/ebpf/rlimit"
 	"github.com/go-errors/errors"
-	"github.com/kubeshark/ebpf/rlimit"
 	"github.com/moby/moby/pkg/parsers/kernel"
 	"github.com/rs/zerolog/log"
 )
@@ -15,9 +15,9 @@ const GlobalWorkerPid = 0
 
 // TODO: cilium/ebpf does not support .kconfig Therefore; for now, we build object files per kernel version.
 
-//go:generate go run github.com/kubeshark/ebpf/cmd/bpf2go@v0.9.1 -target $BPF_TARGET -cflags $BPF_CFLAGS -type tls_chunk -type goid_offsets tracer bpf/tracer.c
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@v0.12.3 -target $BPF_TARGET -cflags $BPF_CFLAGS -type tls_chunk -type goid_offsets tracer bpf/tracer.c
 
-//go:generate go run github.com/kubeshark/ebpf/cmd/bpf2go@v0.9.1 -target $BPF_TARGET -cflags "${BPF_CFLAGS} -DKERNEL_BEFORE_4_6" -type tls_chunk -type goid_offsets tracer46 bpf/tracer.c
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@v0.12.3 -target $BPF_TARGET -cflags "${BPF_CFLAGS} -DKERNEL_BEFORE_4_6" -type tls_chunk -type goid_offsets tracer46 bpf/tracer.c
 
 type Tracer struct {
 	bpfObjects      tracerObjects

--- a/tracer46_bpfel_arm64.go
+++ b/tracer46_bpfel_arm64.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/kubeshark/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 type tracer46GoidOffsets struct {

--- a/tracer46_bpfel_x86.go
+++ b/tracer46_bpfel_x86.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/kubeshark/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 type tracer46GoidOffsets struct {

--- a/tracer_bpfel_arm64.go
+++ b/tracer_bpfel_arm64.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/kubeshark/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 type tracerGoidOffsets struct {

--- a/tracer_bpfel_x86.go
+++ b/tracer_bpfel_x86.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/kubeshark/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 type tracerGoidOffsets struct {


### PR DESCRIPTION
resolves https://github.com/kubeshark/tracer/issues/20

* cgroups V2 support added
* kubeshark/ebpf updated to cilium/ebpf to make code work on last kernels

https://github.com/kubeshark/kubeshark/pull/1496 is required to have on some systems (found whet tested on Linux 6.5.0)