### PR TITLE
fix initialization race condition during start; change log severity

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -123,7 +123,7 @@ func (t *Tracer) addSSLLibPid(procfs string, pid uint32) error {
 	sslLibrary, err := findSsllib(procfs, pid)
 
 	if err != nil {
-		log.Warn().Err(err).Int("pid", int(pid)).Msg("PID skipped no libssl.so found:")
+		log.Trace().Err(err).Int("pid", int(pid)).Msg("PID skipped no libssl.so found:")
 		return nil // hide the error on purpose, it's OK for a process to not use libssl.so
 	} else {
 		log.Info().Str("path", sslLibrary).Int("pid", int(pid)).Msg("Found libssl.so:")


### PR DESCRIPTION
1. Fixes race condition https://github.com/kubeshark/tracer/issues/35:
During the start kubernetes event handler can target TLS pods before tracer fully initialized 

2. Changes log severirty from from `Warn` to `Trace` for https://github.com/kubeshark/tracer/issues/36