### PR TITLE
optimize pod scanning

### DIFF
--- a/bpf/fd_to_address_tracepoints.c
+++ b/bpf/fd_to_address_tracepoints.c
@@ -31,7 +31,7 @@ SEC("tracepoint/syscalls/sys_enter_accept4")
 void sys_enter_accept4(struct sys_enter_accept4_ctx* ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 
-	if (!should_target(id >> 32)) {
+	if (!should_watch(id >> 32)) {
 		return;
 	}
 
@@ -57,7 +57,7 @@ SEC("tracepoint/syscalls/sys_exit_accept4")
 void sys_exit_accept4(struct sys_exit_accept4_ctx* ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 
-	if (!should_target(id >> 32)) {
+	if (!should_watch(id >> 32)) {
 		return;
 	}
 
@@ -124,7 +124,7 @@ SEC("tracepoint/syscalls/sys_enter_connect")
 void sys_enter_connect(struct sys_enter_connect_ctx* ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 
-	if (!should_target(id >> 32)) {
+	if (!should_watch(id >> 32)) {
 		return;
 	}
 
@@ -151,7 +151,7 @@ SEC("tracepoint/syscalls/sys_exit_connect")
 void sys_exit_connect(struct sys_exit_connect_ctx* ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 
-	if (!should_target(id >> 32)) {
+	if (!should_watch(id >> 32)) {
 		return;
 	}
 

--- a/bpf/fd_tracepoints.c
+++ b/bpf/fd_tracepoints.c
@@ -61,7 +61,7 @@ SEC("tracepoint/syscalls/sys_enter_read")
 void sys_enter_read(struct sys_enter_read_write_ctx* ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 
-	if (!should_target(id >> 32)) {
+	if (!should_watch(id >> 32)) {
 		return;
 	}
 
@@ -78,7 +78,7 @@ SEC("tracepoint/syscalls/sys_enter_write")
 void sys_enter_write(struct sys_enter_read_write_ctx* ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 
-	if (!should_target(id >> 32)) {
+	if (!should_watch(id >> 32)) {
 		return;
 	}
 

--- a/bpf/include/maps.h
+++ b/bpf/include/maps.h
@@ -65,7 +65,6 @@ struct goid_offsets {
 };
 
 struct pid_info {
-    __u64 go_tcp_conn_offset;
     __s64 sys_fd_offset;
     __u64 is_interface;
 };
@@ -105,7 +104,8 @@ struct {
     BPF_MAP(_name, BPF_MAP_TYPE_LRU_HASH, _key_type, _value_type, MAX_ENTRIES_LRU_HASH)
 
 // Generic
-BPF_HASH(pids_map, __u32, __u32);
+BPF_HASH(target_pids_map, __u32, __u32);
+BPF_HASH(watch_pids_map, __u32, __u32);
 BPF_HASH(pids_info, struct pid_offset, struct pid_info);
 BPF_LRU_HASH(connection_context, __u64, conn_flags);
 BPF_PERF_OUTPUT(chunks_buffer);

--- a/bpf/include/pids.h
+++ b/bpf/include/pids.h
@@ -6,17 +6,26 @@ Copyright (C) Kubeshark
 #ifndef __PIDS__
 #define __PIDS__
 
-int should_target(__u32 pid) {
-	__u32* shouldTarget = bpf_map_lookup_elem(&pids_map, &pid);
+int _pid_in_map(struct bpf_map_def* pmap, __u32 pid) {
+	__u32* shouldTarget = bpf_map_lookup_elem(pmap, &pid);
 
 	if (shouldTarget != NULL && *shouldTarget == 1) {
 		return 1;
 	}
 
 	__u32 globalPid = 0;
-	__u32* shouldTargetGlobally = bpf_map_lookup_elem(&pids_map, &globalPid);
+	__u32* shouldTargetGlobally = bpf_map_lookup_elem(pmap, &globalPid);
 
 	return shouldTargetGlobally != NULL && *shouldTargetGlobally == 1;
+}
+
+
+int should_target(__u32 pid) {
+	return _pid_in_map(&target_pids_map, pid);
+}
+
+int should_watch(__u32 pid) {
+	return _pid_in_map(&watch_pids_map, pid);
 }
 
 #endif /* __PIDS__ */

--- a/bpf/tcp_kprobes.c
+++ b/bpf/tcp_kprobes.c
@@ -81,7 +81,7 @@ static __always_inline void tcp_kprobe(struct pt_regs* ctx, struct bpf_map_def* 
 
 	__u64 id = bpf_get_current_pid_tgid();
 
-	if (!should_target(id >> 32)) {
+	if (!should_watch(id >> 32)) {
 		return;
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
-	golang.org/x/sys v0.14.1-0.20231108175955-e4099bfacb8c // indirect
+	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.14.1-0.20231108175955-e4099bfacb8c h1:3kC/TjQ+xzIblQv39bCOyRk8fbEeJcDHwbyxPUU2BpA=
-golang.org/x/sys v0.14.1-0.20231108175955-e4099bfacb8c/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.6.0 h1:clScbb1cHjoCkyRbWwBEUZ5H/tIFu5TAXIqaZD0Gcjw=
 golang.org/x/term v0.6.0/go.mod h1:m6U89DPEgQRMq3DNkDClhWw02AUbt2daBVO4cn4Hv9U=

--- a/pkg/kubernetes/loader.go
+++ b/pkg/kubernetes/loader.go
@@ -2,12 +2,11 @@ package kubernetes
 
 import (
 	"github.com/rs/zerolog/log"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-func NewFromInCluster(errOut chan error, callback func(pods []v1.Pod) error) *Watcher {
+func NewFromInCluster(errOut chan error, callback callbackPodsChanged) *Watcher {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		log.Warn().Err(err).Send()

--- a/tls_process_discoverer.go
+++ b/tls_process_discoverer.go
@@ -25,7 +25,9 @@ func (t *Tracer) updateTargets(addedWatchedPods []v1.Pod, removedWatchedPods []v
 			log.Error().Str("pod", pod.Name).Msg("untarget pod is not watched:")
 			continue
 		}
-		p.Untarget(&t.bpfObjects)
+		if err := p.Untarget(&t.bpfObjects); err != nil {
+			return err
+		}
 	}
 
 	for _, pod := range removedWatchedPods {
@@ -33,7 +35,9 @@ func (t *Tracer) updateTargets(addedWatchedPods []v1.Pod, removedWatchedPods []v
 		if !ok {
 			continue
 		}
-		p.RemoveProbes(&t.bpfObjects)
+		if err := p.RemoveProbes(&t.bpfObjects); err != nil {
+			return err
+		}
 		delete(t.watchingPods, pod.UID)
 	}
 

--- a/tls_watcher.go
+++ b/tls_watcher.go
@@ -197,7 +197,7 @@ func (p *probesGoTls) InstallProbes(procfs string, bpfObjects *tracerObjects) (b
 func (p *probesGoTls) UninstallProbes(bpfObjects *tracerObjects) error {
 	pidsInfo := bpfObjects.tracerMaps.PidsInfo
 
-	for offset := range p.pidOffsets {
+	for _, offset := range p.pidOffsets {
 		if err := pidsInfo.Delete(offset); err != nil {
 			return errors.Wrap(err, 0)
 		}

--- a/tls_watcher.go
+++ b/tls_watcher.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/go-errors/errors"
+	"github.com/rs/zerolog/log"
+)
+
+type probesLibSsl struct {
+	pid        uint32
+	sslLibrary string
+	sslHooks   sslHooks
+}
+
+type probesGoTls struct {
+	pid        uint32
+	exePath    string
+	goGooks    goHooks
+	pidOffsets []pidOffset
+}
+
+type tlsProbe interface {
+	InstallProbes(procfs string, bpfObjects *tracerObjects) (bool, error)
+	UninstallProbes(bpfObjects *tracerObjects) error
+
+	Target(bpfObjects *tracerObjects) error
+	Untarget(bpfObjects *tracerObjects) error
+}
+
+type podWatcher struct {
+	pid       uint32
+	tlsProbes []tlsProbe
+}
+
+func NewPodWatcher(procfs string, bpfObjects *tracerObjects, pid uint32) (*podWatcher, error) {
+	pw := podWatcher{
+		pid: pid,
+		tlsProbes: []tlsProbe{
+			&probesLibSsl{pid: pid},
+			&probesGoTls{pid: pid},
+		},
+	}
+
+	if err := pw.tryInstallProbes(procfs, bpfObjects); err != nil {
+		return nil, err
+	}
+
+	if len(pw.tlsProbes) == 0 {
+		return nil, nil
+	}
+
+	return &pw, nil
+}
+
+func (p *podWatcher) tryInstallProbes(procfs string, bpfObjects *tracerObjects) error {
+	var activeTlsProbes []tlsProbe
+	for _, probe := range p.tlsProbes {
+		installed, err := probe.InstallProbes(procfs, bpfObjects)
+		if err != nil {
+			return err
+		}
+		if installed {
+			activeTlsProbes = append(activeTlsProbes, probe)
+		}
+	}
+	p.tlsProbes = activeTlsProbes
+	return nil
+}
+
+func (p *podWatcher) Target(bpfObjects *tracerObjects) (err error) {
+	for _, probe := range p.tlsProbes {
+		if err = probe.Target(bpfObjects); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (p *podWatcher) Untarget(bpfObjects *tracerObjects) (err error) {
+	for _, probe := range p.tlsProbes {
+		if err = probe.Untarget(bpfObjects); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (p *podWatcher) RemoveProbes(bpfObjects *tracerObjects) (err error) {
+	for _, probe := range p.tlsProbes {
+		if err = probe.UninstallProbes(bpfObjects); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (p *probesLibSsl) InstallProbes(procfs string, bpfObjects *tracerObjects) (bool, error) {
+	sslLibrary, err := findSsllib(procfs, p.pid)
+
+	if err != nil {
+		log.Trace().Err(err).Int("pid", int(p.pid)).Msg("PID skipped no libssl.so found:")
+		return false, nil // hide the error on purpose, it's OK for a process to not use libssl.so
+	} else {
+		log.Info().Str("path", sslLibrary).Int("pid", int(p.pid)).Msg("Found libssl.so:")
+	}
+	p.sslLibrary = sslLibrary
+
+	if err = p.sslHooks.installUprobes(bpfObjects, sslLibrary); err != nil {
+		return false, err
+	}
+
+	if err := watchPidMap(bpfObjects, p.pid); err != nil {
+		return false, err
+	}
+
+	log.Info().Msg(fmt.Sprintf("Watching TLS (pid: %v) (libssl: %v)", p.pid, p.sslLibrary))
+
+	return true, nil
+}
+
+func (p *probesLibSsl) UninstallProbes(bpfObjects *tracerObjects) error {
+	errs := p.sslHooks.close()
+
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := unwatchPidMap(bpfObjects, p.pid); err != nil {
+		return err
+	}
+
+	log.Info().Msg(fmt.Sprintf("Unwatching TLS (pid: %v) (libssl: %v)", p.pid, p.sslLibrary))
+	return nil
+}
+
+func (p *probesLibSsl) Target(bpfObjects *tracerObjects) error {
+	if err := targetPidMap(bpfObjects, p.pid); err != nil {
+		return err
+	}
+	log.Info().Msg(fmt.Sprintf("Targeting TLS (pid: %v) (libssl: %v)", p.pid, p.sslLibrary))
+	return nil
+}
+
+func (p *probesLibSsl) Untarget(bpfObjects *tracerObjects) error {
+	if err := untargetPidMap(bpfObjects, p.pid); err != nil {
+		return err
+	}
+	log.Info().Msg(fmt.Sprintf("Untargeting TLS (pid: %v) (libssl: %v)", p.pid, p.sslLibrary))
+	return nil
+}
+
+func (p *probesGoTls) InstallProbes(procfs string, bpfObjects *tracerObjects) (bool, error) {
+	exePath, err := findLibraryByPid(procfs, p.pid, "")
+	if err != nil {
+		return false, err
+	}
+
+	p.exePath = exePath
+
+	offsets, err := p.goGooks.installUprobes(bpfObjects, exePath)
+	if err != nil {
+		log.Info().Msg(fmt.Sprintf("PID skipped not a Go binary or symbol table is stripped pid: %v %v err: %v", p.pid, exePath, err))
+		return false, nil // hide the error on purpose, its OK for a process to be not a Go binary or stripped Go binary
+	}
+
+	pidsInfo := bpfObjects.tracerMaps.PidsInfo
+
+	p.pidOffsets = make([]pidOffset, 0)
+	for _, ncOffset := range offsets.NetConnOffsets {
+		offset := pidOffset{
+			pid:    uint64(p.pid),
+			offset: ncOffset.symbolOffset,
+		}
+		pi := pidInfo{
+			sysFdOffset: ncOffset.socketSysFdOffset,
+			isInterface: uint64(ncOffset.isGoInterface),
+		}
+		if err := pidsInfo.Put(offset, pi); err != nil {
+			return false, errors.Wrap(err, 0)
+		}
+		p.pidOffsets = append(p.pidOffsets, offset)
+	}
+
+	if err := watchPidMap(bpfObjects, p.pid); err != nil {
+		return false, err
+	}
+
+	log.Info().Msg(fmt.Sprintf("Watching TLS (pid: %v) (Go: %v)", p.pid, p.exePath))
+
+	return true, nil
+}
+
+func (p *probesGoTls) UninstallProbes(bpfObjects *tracerObjects) error {
+	pidsInfo := bpfObjects.tracerMaps.PidsInfo
+
+	for offset := range p.pidOffsets {
+		if err := pidsInfo.Delete(offset); err != nil {
+			return errors.Wrap(err, 0)
+		}
+	}
+
+	errs := p.goGooks.close()
+
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := unwatchPidMap(bpfObjects, p.pid); err != nil {
+		return err
+	}
+
+	log.Info().Msg(fmt.Sprintf("Unwatching TLS (pid: %v) (Go: %v)", p.pid, p.exePath))
+	return nil
+}
+
+func (p *probesGoTls) Target(bpfObjects *tracerObjects) error {
+	if err := targetPidMap(bpfObjects, p.pid); err != nil {
+		return err
+	}
+	log.Info().Msg(fmt.Sprintf("Targeting TLS (pid: %v) (Go: %v)", p.pid, p.exePath))
+
+	return nil
+}
+
+func (p *probesGoTls) Untarget(bpfObjects *tracerObjects) error {
+	if err := untargetPidMap(bpfObjects, p.pid); err != nil {
+		return err
+	}
+	log.Info().Msg(fmt.Sprintf("Untargeting TLS (pid: %v) (Go: %v)", p.pid, p.exePath))
+
+	return nil
+}
+
+func targetPidMap(bpfObjects *tracerObjects, pid uint32) error {
+	return addPidToMap(bpfObjects.tracerMaps.TargetPidsMap, pid)
+}
+func untargetPidMap(bpfObjects *tracerObjects, pid uint32) error {
+	return delPidFromMap(bpfObjects.tracerMaps.TargetPidsMap, pid)
+}
+
+func watchPidMap(bpfObjects *tracerObjects, pid uint32) error {
+	return addPidToMap(bpfObjects.tracerMaps.WatchPidsMap, pid)
+}
+func unwatchPidMap(bpfObjects *tracerObjects, pid uint32) error {
+	return delPidFromMap(bpfObjects.tracerMaps.WatchPidsMap, pid)
+}
+
+func addPidToMap(pidmap *ebpf.Map, pid uint32) error {
+	if err := pidmap.Put(pid, uint32(1)); err != nil {
+		return errors.Wrap(err, 0)
+	}
+	return nil
+}
+
+func delPidFromMap(pidmap *ebpf.Map, pid uint32) error {
+	if err := pidmap.Delete(pid); err != nil {
+		return errors.Wrap(err, 0)
+	}
+	return nil
+}

--- a/tracer.go
+++ b/tracer.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"syscall"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/go-errors/errors"
 	"github.com/moby/moby/pkg/parsers/kernel"
 	"github.com/rs/zerolog/log"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const GlobalWorkerPid = 0
@@ -31,13 +33,14 @@ type Tracer struct {
 	registeredPids       sync.Map
 	registeredPidOffsets sync.Map
 	procfs               string
+	isCgroupV2           bool
+	watchingPods         map[types.UID]*podWatcher
 }
 
 // struct pid_info from maps.h
 type pidInfo struct {
-	goTcpConnOffset uint64
-	sysFdOffset     int64
-	isInterface     uint64
+	sysFdOffset int64
+	isInterface uint64
 }
 
 // struct fd_offset from maps.h
@@ -65,7 +68,17 @@ func (t *Tracer) Init(
 		return err
 	}
 
-	log.Info().Msg(fmt.Sprintf("Detected Linux kernel version: %s", kernelVersion))
+	cgroupsVersion := "1"
+	const cgroupV2MagicNumber = 0x63677270
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs("/sys/fs/cgroup/", &stat); err != nil {
+		log.Error().Err(err).Msg("read cgroups information failed:")
+	} else if stat.Type == cgroupV2MagicNumber {
+		t.isCgroupV2 = true
+		cgroupsVersion = "2"
+	}
+
+	log.Info().Msg(fmt.Sprintf("Detected Linux kernel version: %s cgroups version: %v", kernelVersion, cgroupsVersion))
 
 	t.bpfObjects = tracerObjects{}
 	// TODO: cilium/ebpf does not support .kconfig Therefore; for now, we load object files according to kernel version.
@@ -125,14 +138,26 @@ func (t *Tracer) pollForLogging() {
 	t.bpfLogger.poll()
 }
 
+var globalProbeSSL *probesLibSsl
+
 func (t *Tracer) globalSSLLibTarget(procfs string, pid string) error {
 	_pid, err := strconv.Atoi(pid)
 	if err != nil {
 		return err
 	}
 
-	return t.addSSLLibPid(procfs, uint32(_pid))
+	globalProbeSSL = &probesLibSsl{pid: uint32(_pid)}
+	installed, err := globalProbeSSL.InstallProbes(procfs, &tracer.bpfObjects)
+	if err != nil {
+		return err
+	}
+	if !installed {
+		return fmt.Errorf("install global ssllib failed")
+	}
+	return globalProbeSSL.Target(&tracer.bpfObjects)
 }
+
+var globalProbeGoTls *probesGoTls
 
 func (t *Tracer) globalGoTarget(procfs string, pid string) error {
 	_pid, err := strconv.Atoi(pid)
@@ -140,80 +165,15 @@ func (t *Tracer) globalGoTarget(procfs string, pid string) error {
 		return err
 	}
 
-	return t.targetGoPid(procfs, uint32(_pid))
-}
-
-func (t *Tracer) addSSLLibPid(procfs string, pid uint32) error {
-	sslLibrary, err := findSsllib(procfs, pid)
-
+	globalProbeGoTls = &probesGoTls{pid: uint32(_pid)}
+	installed, err := globalProbeGoTls.InstallProbes(procfs, &tracer.bpfObjects)
 	if err != nil {
-		log.Trace().Err(err).Int("pid", int(pid)).Msg("PID skipped no libssl.so found:")
-		return nil // hide the error on purpose, it's OK for a process to not use libssl.so
-	} else {
-		log.Info().Str("path", sslLibrary).Int("pid", int(pid)).Msg("Found libssl.so:")
+		return err
 	}
-
-	return t.targetSSLLibPid(pid, sslLibrary)
-}
-
-func (t *Tracer) addGoPid(procfs string, pid uint32) error {
-	return t.targetGoPid(procfs, pid)
-}
-
-func (t *Tracer) removePid(pid uint32) error {
-	log.Info().Msg(fmt.Sprintf("Removing PID (pid: %v)", pid))
-
-	pids := t.bpfObjects.tracerMaps.PidsMap
-
-	if err := pids.Delete(pid); err != nil {
-		return errors.Wrap(err, 0)
+	if !installed {
+		return fmt.Errorf("install global GoTls failed")
 	}
-
-	return nil
-}
-
-func (t *Tracer) removePidOffsets(pid uint32, offsets []pidOffset) error {
-	log.Info().Msg(fmt.Sprintf("Removing PID offsets (pid: %v)", pid))
-
-	pidOffsets := t.bpfObjects.tracerMaps.PidsInfo
-
-	for _, o := range offsets {
-		if err := pidOffsets.Delete(o); err != nil {
-			return errors.Wrap(err, 0)
-		}
-	}
-
-	return nil
-}
-
-func (t *Tracer) clearPids() {
-	t.registeredPids.Range(func(key, v interface{}) bool {
-		pid := key.(uint32)
-		if pid == GlobalWorkerPid {
-			return true
-		}
-
-		if err := t.removePid(pid); err != nil {
-			logError(err)
-		}
-		t.registeredPids.Delete(key)
-		return true
-	})
-
-	t.registeredPidOffsets.Range(func(key, v interface{}) bool {
-		pid := key.(uint32)
-		if pid == GlobalWorkerPid {
-			return true
-		}
-
-		offsets := v.([]pidOffset)
-		if err := t.removePidOffsets(pid, offsets); err != nil {
-			logError(err)
-		}
-		t.registeredPidOffsets.Delete(key)
-		return true
-	})
-
+	return globalProbeSSL.Target(&tracer.bpfObjects)
 }
 
 func (t *Tracer) close() []error {
@@ -252,76 +212,6 @@ func setupRLimit() error {
 	if err != nil {
 		return errors.New(fmt.Sprintf("%s: %v", "SYS_RESOURCE is required to change rlimits for eBPF", err))
 	}
-
-	return nil
-}
-
-func (t *Tracer) targetSSLLibPid(pid uint32, sslLibrary string) error {
-	newSsl := sslHooks{}
-
-	if err := newSsl.installUprobes(&t.bpfObjects, sslLibrary); err != nil {
-		return err
-	}
-
-	log.Info().Msg(fmt.Sprintf("Targeting TLS (pid: %v) (libssl: %v)", pid, sslLibrary))
-
-	t.sslHooksStructs = append(t.sslHooksStructs, newSsl)
-
-	pids := t.bpfObjects.tracerMaps.PidsMap
-
-	if err := pids.Put(pid, uint32(1)); err != nil {
-		return errors.Wrap(err, 0)
-	}
-
-	t.registeredPids.Store(pid, true)
-
-	return nil
-}
-
-func (t *Tracer) targetGoPid(procfs string, pid uint32) error {
-	exePath, err := findLibraryByPid(procfs, pid, "")
-	if err != nil {
-		return err
-	}
-
-	hooks := goHooks{}
-
-	var offsets goOffsets
-	if offsets, err = hooks.installUprobes(&t.bpfObjects, exePath); err != nil {
-		log.Info().Msg(fmt.Sprintf("PID skipped not a Go binary or symbol table is stripped pid: %v %v err: %v", pid, exePath, err))
-		return nil // hide the error on purpose, its OK for a process to be not a Go binary or stripped Go binary
-	}
-
-	log.Info().Msg(fmt.Sprintf("Targeting TLS (pid: %v) (Go: %v)", pid, exePath))
-
-	t.goHooksStructs = append(t.goHooksStructs, hooks)
-
-	pids := t.bpfObjects.tracerMaps.PidsMap
-
-	if err := pids.Put(pid, uint32(1)); err != nil {
-		return errors.Wrap(err, 0)
-	}
-
-	pidOffsets := make([]pidOffset, 0)
-	pidsInfo := t.bpfObjects.tracerMaps.PidsInfo
-	for _, ncOffset := range offsets.NetConnOffsets {
-		offset := pidOffset{
-			pid:    uint64(pid),
-			offset: ncOffset.symbolOffset,
-		}
-		pi := pidInfo{
-			goTcpConnOffset: offsets.GoTcpConnOffset,
-			sysFdOffset:     ncOffset.socketSysFdOffset,
-			isInterface:     uint64(ncOffset.isGoInterface),
-		}
-		if err := pidsInfo.Put(offset, pi); err != nil {
-			return errors.Wrap(err, 0)
-		}
-		pidOffsets = append(pidOffsets, offset)
-	}
-	t.registeredPidOffsets.Store(pid, pidOffsets)
-
-	t.registeredPids.Store(pid, true)
 
 	return nil
 }

--- a/tracer.go
+++ b/tracer.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"strconv"
-	"sync"
 	"syscall"
 
 	"github.com/cilium/ebpf"
@@ -23,18 +22,16 @@ const GlobalWorkerPid = 0
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go@v0.12.3 -target $BPF_TARGET -cflags "${BPF_CFLAGS} -DKERNEL_BEFORE_4_6" -type tls_chunk -type goid_offsets tracer46 bpf/tracer.c
 
 type Tracer struct {
-	bpfObjects           tracerObjects
-	syscallHooks         syscallHooks
-	tcpKprobeHooks       tcpKprobeHooks
-	sslHooksStructs      []sslHooks
-	goHooksStructs       []goHooks
-	poller               *tlsPoller
-	bpfLogger            *bpfLogger
-	registeredPids       sync.Map
-	registeredPidOffsets sync.Map
-	procfs               string
-	isCgroupV2           bool
-	watchingPods         map[types.UID]*podWatcher
+	bpfObjects      tracerObjects
+	syscallHooks    syscallHooks
+	tcpKprobeHooks  tcpKprobeHooks
+	sslHooksStructs []sslHooks
+	goHooksStructs  []goHooks
+	poller          *tlsPoller
+	bpfLogger       *bpfLogger
+	procfs          string
+	isCgroupV2      bool
+	watchingPods    map[types.UID]*podWatcher
 }
 
 // struct pid_info from maps.h


### PR DESCRIPTION
resolves https://github.com/kubeshark/tracer/issues/41

Changes:

- Instead of targeting only, pod can be watched by tracer, watching means follow kernel hooks without intercepting TLS data. Tracer watches all pods in target namespaces and targets all pods matches target regexp.

- Instead of re-scanning pods from scratch tracer rescans only when namespace targeting is changed. On regexp change it only targets/untargets pods