### PR TITLE
Intercept 'accept' syscall

### DIFF
--- a/syscall_hooks.go
+++ b/syscall_hooks.go
@@ -12,6 +12,8 @@ type syscallHooks struct {
 	sysExitWrite    link.Link
 	sysEnterAccept4 link.Link
 	sysExitAccept4  link.Link
+	sysEnterAccept  link.Link
+	sysExitAccept   link.Link
 	sysEnterConnect link.Link
 	sysExitConnect  link.Link
 }
@@ -49,7 +51,19 @@ func (s *syscallHooks) installSyscallHooks(bpfObjects *tracerObjects) error {
 		return errors.Wrap(err, 0)
 	}
 
+	s.sysEnterAccept, err = link.Tracepoint("syscalls", "sys_enter_accept", bpfObjects.SysEnterAccept4, nil)
+
+	if err != nil {
+		return errors.Wrap(err, 0)
+	}
+
 	s.sysExitAccept4, err = link.Tracepoint("syscalls", "sys_exit_accept4", bpfObjects.SysExitAccept4, nil)
+
+	if err != nil {
+		return errors.Wrap(err, 0)
+	}
+
+	s.sysExitAccept, err = link.Tracepoint("syscalls", "sys_exit_accept", bpfObjects.SysExitAccept4, nil)
 
 	if err != nil {
 		return errors.Wrap(err, 0)


### PR DESCRIPTION
Tracer used server hooks only on 'accept4', as p result, not all TLS server traffic is intercepted

Some application using 'accept' which is important to hook into as well.

