### PR TITLE
Fix TLS TCP flow direction in case of server packet arrives first

### DIFF
--- a/tls_poller.go
+++ b/tls_poller.go
@@ -138,8 +138,8 @@ func (p *tlsPoller) handleTlsChunk(chunk *tracerTlsChunk, streamsMap *TcpStreamM
 		streamsMap.Store(stream.getId(), stream)
 		p.streams[key] = stream
 
-		stream.client = NewTlsReader(p.buildTcpId(address, true), stream, true)
-		stream.server = NewTlsReader(p.buildTcpId(address, false), stream, false)
+		stream.client = NewTlsReader(p.buildTcpId(address, chunk.isClient()), stream, true)
+		stream.server = NewTlsReader(p.buildTcpId(address, !chunk.isClient()), stream, false)
 	}
 
 	reader := chunk.getReader(stream)


### PR DESCRIPTION
When the server packet arrives first to the TLS, it is required to make right flow from client ports to server ports