### PR TITLE
Add parameters for TLS interception in libssl custom names

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	_ "net/http/pprof" // Blank import to pprof
 	"os"
+	"strings"
 	"time"
 
 	"github.com/kubeshark/tracer/misc"
@@ -29,9 +30,22 @@ var globCbuf = flag.Int("cbuf", 0, fmt.Sprintf("Keep last N packets in circular 
 
 var disableEbpfCapture = flag.Bool("disable-ebpf", false, "Disable capture packet via eBPF")
 
+type sslListArray []string
+
+func (i *sslListArray) String() string {
+	return strings.Join((*i)[:], ",")
+}
+func (i *sslListArray) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+var sslLibsGlobal sslListArray
+
 var tracer *Tracer
 
 func main() {
+	flag.Var(&sslLibsGlobal, "ssl-libname", "Custom libssl library name")
 	flag.Parse()
 
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)

--- a/ssllib_finder.go
+++ b/ssllib_finder.go
@@ -46,8 +46,18 @@ func findLibraryByPid(procfs string, pid uint32, libraryName string) (string, er
 
 		fpath := parts[5]
 
-		if libraryName != "" && !strings.Contains(fpath, libraryName) {
-			continue
+		if libraryName != "" {
+			found := strings.Contains(fpath, libraryName)
+
+			for _, name := range sslLibsGlobal {
+				if found {
+					break
+				}
+				found = strings.Contains(fpath, name)
+			}
+			if !found {
+				continue
+			}
 		}
 
 		fullpath := fmt.Sprintf("%v/%v/root%v", procfs, pid, fpath)


### PR DESCRIPTION
New parameter added to tracer with name `-ssl-libname` to intercept TLS traffic in libssl with non-standard names, multiple names can be provided, for example:
```
      - command:
        - ./tracer
        - -procfs
        - /hostproc
        - -ssl-libname
        - opensslname1
        - -ssl-libname
        - opensslname2
 ```