### PR TITLE
Fix eBPF packet sniffer race conditions

### DIFF
--- a/bpf/include/maps.h
+++ b/bpf/include/maps.h
@@ -116,15 +116,6 @@ struct {
     __type(value, __u64);
 } pkt_id SEC(".maps");
 
-
-struct pkt_flow {
-    __u32 size;
-    __u32 src_ip;
-    __u16 src_port;
-    __u8 proto;
-    __u8 pad;
-};
-
 struct pkt_data {
     __u64 cgroup_id;
     __u32 pad1;
@@ -170,6 +161,6 @@ BPF_LRU_HASH(go_kernel_write_context, __u64, __u32);
 BPF_LRU_HASH(go_kernel_read_context, __u64, __u32);
 BPF_LRU_HASH(go_user_kernel_write_context, __u64, struct address_info);
 BPF_LRU_HASH(go_user_kernel_read_context, __u64, struct address_info);
-BPF_LRU_HASH(pkt_context, struct pkt_flow, struct pkt_data);
+BPF_LRU_HASH(pkt_context, __u64, struct pkt_data);
 
 #endif /* __MAPS__ */


### PR DESCRIPTION
In certain conditions, `cgroup_skb/` eBPF program is called few times in a raw (for the same flow) and `tc/` program is called after that sequence. Because of that not all packets from the flow get delivered.

Fixed by having `sk_buff` pointer as a eBPF map key

fixes https://github.com/kubeshark/worker/issues/162