### PR TITLE
Remove bpf_ktime_get_tai_ns call for old kernels

### DIFF
--- a/bpf/common.c
+++ b/bpf/common.c
@@ -95,7 +95,11 @@ static __always_inline void output_ssl_chunk(struct pt_regs* ctx, struct ssl_inf
     }
 
     chunk->flags = flags;
+#ifndef EBPF_FALLBACK
     chunk->timestamp = bpf_ktime_get_tai_ns();
+#else
+    chunk->timestamp = 0;
+#endif
     chunk->cgroup_id = cgroup_id;
     chunk->pid = id >> 32;
     chunk->tgid = id;

--- a/bpf/packet_sniffer.c
+++ b/bpf/packet_sniffer.c
@@ -1,4 +1,4 @@
-#ifndef NO_PACKET_SNIFFER
+#ifndef EBPF_FALLBACK
 
 /*
     -------------------------------------------------------------------------------
@@ -378,4 +378,4 @@ static __always_inline int parse_packet(struct __sk_buff* skb, int is_tc, __u32*
     return 6;
 }
 
-#endif // NO_PACKET_SNIFFER
+#endif // EBPF_FALLBACK

--- a/socket/packet_unix_socket.go
+++ b/socket/packet_unix_socket.go
@@ -44,7 +44,11 @@ func (s *SocketPcap) WritePacket(timestamp uint64, cgroupId uint64, direction ui
 
 	p := unixpacket.PacketUnixSocket(hdrBytes)
 	hdr := p.GetHeader()
-	hdr.Timestamp = timestamp - s.getTAIOffset()
+	if timestamp != 0 {
+		hdr.Timestamp = timestamp - s.getTAIOffset()
+	} else {
+		hdr.Timestamp = uint64(time.Now().UnixNano())
+	}
 	hdr.CgroupID = cgroupId
 	hdr.Direction = unixpacket.PacketDirection(direction)
 	// clear buffer at the end as soon as it is prepended with specific data

--- a/tracer_cgroup.go
+++ b/tracer_cgroup.go
@@ -72,7 +72,6 @@ func (t *tracerCgroup) scanPidsV2(procfs string, pids []os.DirEntry, containerId
 
 		bytes, err := os.ReadFile(fpath)
 		if err != nil {
-			log.Debug().Err(err).Str("pid", pid.Name()).Msg("Couldn't read cgroup file.")
 			continue
 		}
 
@@ -266,7 +265,7 @@ func normalizeCgroup(cgrouppath string) string {
 	basename := strings.TrimSpace(path.Base(cgrouppath))
 
 	if strings.Contains(basename, "-") {
-		basename = basename[strings.Index(basename, "-")+1:]
+		basename = basename[strings.LastIndex(basename, "-")+1:]
 	}
 
 	if strings.Contains(basename, ".") {


### PR DESCRIPTION
`bpf_ktime_get_tai_ns` is only supported for kernels 6.1+