### PR TITLE
Replace security_socket_accept tracepoint with do_accept kprobe 

### DIFF
--- a/tcp_kprobe_hooks.go
+++ b/tcp_kprobe_hooks.go
@@ -31,9 +31,9 @@ func (s *tcpKprobeHooks) installTcpKprobeHooks(bpfObjects *tracerObjects) error 
 		return errors.Wrap(err, 0)
 	}
 
-	s.accept, err = link.Kretprobe("sys_accept4", bpfObjects.SyscallAccept4, nil)
+	s.accept, err = link.Kretprobe("sys_accept4", bpfObjects.SyscallAccept4Ret, nil)
 
-	s.accept4, err = link.Kprobe("security_socket_accept", bpfObjects.SecuritySocketAccept, nil)
+	s.accept4, err = link.Kprobe("security_socket_accept", bpfObjects.SyscallAccept4, nil)
 	if err != nil {
 		return errors.Wrap(err, 0)
 	}

--- a/tracer46_bpfel_x86.go
+++ b/tracer46_bpfel_x86.go
@@ -144,7 +144,6 @@ type tracer46ProgramSpecs struct {
 	GoCryptoTlsAbiInternalWriteEx *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi_internal_write_ex"`
 	PacketPullEgress              *ebpf.ProgramSpec `ebpf:"packet_pull_egress"`
 	PacketPullIngress             *ebpf.ProgramSpec `ebpf:"packet_pull_ingress"`
-	SecuritySocketAccept          *ebpf.ProgramSpec `ebpf:"security_socket_accept"`
 	SslRead                       *ebpf.ProgramSpec `ebpf:"ssl_read"`
 	SslReadEx                     *ebpf.ProgramSpec `ebpf:"ssl_read_ex"`
 	SslRetRead                    *ebpf.ProgramSpec `ebpf:"ssl_ret_read"`
@@ -162,6 +161,7 @@ type tracer46ProgramSpecs struct {
 	SysExitRead                   *ebpf.ProgramSpec `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.ProgramSpec `ebpf:"sys_exit_write"`
 	SyscallAccept4                *ebpf.ProgramSpec `ebpf:"syscall__accept4"`
+	SyscallAccept4Ret             *ebpf.ProgramSpec `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.ProgramSpec `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.ProgramSpec `ebpf:"tcp_recvmsg"`
 	TcpSendmsg                    *ebpf.ProgramSpec `ebpf:"tcp_sendmsg"`
@@ -294,7 +294,6 @@ type tracer46Programs struct {
 	GoCryptoTlsAbiInternalWriteEx *ebpf.Program `ebpf:"go_crypto_tls_abi_internal_write_ex"`
 	PacketPullEgress              *ebpf.Program `ebpf:"packet_pull_egress"`
 	PacketPullIngress             *ebpf.Program `ebpf:"packet_pull_ingress"`
-	SecuritySocketAccept          *ebpf.Program `ebpf:"security_socket_accept"`
 	SslRead                       *ebpf.Program `ebpf:"ssl_read"`
 	SslReadEx                     *ebpf.Program `ebpf:"ssl_read_ex"`
 	SslRetRead                    *ebpf.Program `ebpf:"ssl_ret_read"`
@@ -312,6 +311,7 @@ type tracer46Programs struct {
 	SysExitRead                   *ebpf.Program `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.Program `ebpf:"sys_exit_write"`
 	SyscallAccept4                *ebpf.Program `ebpf:"syscall__accept4"`
+	SyscallAccept4Ret             *ebpf.Program `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.Program `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.Program `ebpf:"tcp_recvmsg"`
 	TcpSendmsg                    *ebpf.Program `ebpf:"tcp_sendmsg"`
@@ -332,7 +332,6 @@ func (p *tracer46Programs) Close() error {
 		p.GoCryptoTlsAbiInternalWriteEx,
 		p.PacketPullEgress,
 		p.PacketPullIngress,
-		p.SecuritySocketAccept,
 		p.SslRead,
 		p.SslReadEx,
 		p.SslRetRead,
@@ -350,6 +349,7 @@ func (p *tracer46Programs) Close() error {
 		p.SysExitRead,
 		p.SysExitWrite,
 		p.SyscallAccept4,
+		p.SyscallAccept4Ret,
 		p.TcpConnect,
 		p.TcpRecvmsg,
 		p.TcpSendmsg,

--- a/tracer_bpfel_x86.go
+++ b/tracer_bpfel_x86.go
@@ -144,7 +144,6 @@ type tracerProgramSpecs struct {
 	GoCryptoTlsAbiInternalWriteEx *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi_internal_write_ex"`
 	PacketPullEgress              *ebpf.ProgramSpec `ebpf:"packet_pull_egress"`
 	PacketPullIngress             *ebpf.ProgramSpec `ebpf:"packet_pull_ingress"`
-	SecuritySocketAccept          *ebpf.ProgramSpec `ebpf:"security_socket_accept"`
 	SslRead                       *ebpf.ProgramSpec `ebpf:"ssl_read"`
 	SslReadEx                     *ebpf.ProgramSpec `ebpf:"ssl_read_ex"`
 	SslRetRead                    *ebpf.ProgramSpec `ebpf:"ssl_ret_read"`
@@ -162,6 +161,7 @@ type tracerProgramSpecs struct {
 	SysExitRead                   *ebpf.ProgramSpec `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.ProgramSpec `ebpf:"sys_exit_write"`
 	SyscallAccept4                *ebpf.ProgramSpec `ebpf:"syscall__accept4"`
+	SyscallAccept4Ret             *ebpf.ProgramSpec `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.ProgramSpec `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.ProgramSpec `ebpf:"tcp_recvmsg"`
 	TcpSendmsg                    *ebpf.ProgramSpec `ebpf:"tcp_sendmsg"`
@@ -294,7 +294,6 @@ type tracerPrograms struct {
 	GoCryptoTlsAbiInternalWriteEx *ebpf.Program `ebpf:"go_crypto_tls_abi_internal_write_ex"`
 	PacketPullEgress              *ebpf.Program `ebpf:"packet_pull_egress"`
 	PacketPullIngress             *ebpf.Program `ebpf:"packet_pull_ingress"`
-	SecuritySocketAccept          *ebpf.Program `ebpf:"security_socket_accept"`
 	SslRead                       *ebpf.Program `ebpf:"ssl_read"`
 	SslReadEx                     *ebpf.Program `ebpf:"ssl_read_ex"`
 	SslRetRead                    *ebpf.Program `ebpf:"ssl_ret_read"`
@@ -312,6 +311,7 @@ type tracerPrograms struct {
 	SysExitRead                   *ebpf.Program `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.Program `ebpf:"sys_exit_write"`
 	SyscallAccept4                *ebpf.Program `ebpf:"syscall__accept4"`
+	SyscallAccept4Ret             *ebpf.Program `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.Program `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.Program `ebpf:"tcp_recvmsg"`
 	TcpSendmsg                    *ebpf.Program `ebpf:"tcp_sendmsg"`
@@ -332,7 +332,6 @@ func (p *tracerPrograms) Close() error {
 		p.GoCryptoTlsAbiInternalWriteEx,
 		p.PacketPullEgress,
 		p.PacketPullIngress,
-		p.SecuritySocketAccept,
 		p.SslRead,
 		p.SslReadEx,
 		p.SslRetRead,
@@ -350,6 +349,7 @@ func (p *tracerPrograms) Close() error {
 		p.SysExitRead,
 		p.SysExitWrite,
 		p.SyscallAccept4,
+		p.SyscallAccept4Ret,
 		p.TcpConnect,
 		p.TcpRecvmsg,
 		p.TcpSendmsg,

--- a/tracernosniff_bpfel_x86.go
+++ b/tracernosniff_bpfel_x86.go
@@ -140,7 +140,6 @@ type tracerNoSniffProgramSpecs struct {
 	GoCryptoTlsAbiInternalReadEx  *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi_internal_read_ex"`
 	GoCryptoTlsAbiInternalWrite   *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi_internal_write"`
 	GoCryptoTlsAbiInternalWriteEx *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi_internal_write_ex"`
-	SecuritySocketAccept          *ebpf.ProgramSpec `ebpf:"security_socket_accept"`
 	SslRead                       *ebpf.ProgramSpec `ebpf:"ssl_read"`
 	SslReadEx                     *ebpf.ProgramSpec `ebpf:"ssl_read_ex"`
 	SslRetRead                    *ebpf.ProgramSpec `ebpf:"ssl_ret_read"`
@@ -158,6 +157,7 @@ type tracerNoSniffProgramSpecs struct {
 	SysExitRead                   *ebpf.ProgramSpec `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.ProgramSpec `ebpf:"sys_exit_write"`
 	SyscallAccept4                *ebpf.ProgramSpec `ebpf:"syscall__accept4"`
+	SyscallAccept4Ret             *ebpf.ProgramSpec `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.ProgramSpec `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.ProgramSpec `ebpf:"tcp_recvmsg"`
 	TcpSendmsg                    *ebpf.ProgramSpec `ebpf:"tcp_sendmsg"`
@@ -286,7 +286,6 @@ type tracerNoSniffPrograms struct {
 	GoCryptoTlsAbiInternalReadEx  *ebpf.Program `ebpf:"go_crypto_tls_abi_internal_read_ex"`
 	GoCryptoTlsAbiInternalWrite   *ebpf.Program `ebpf:"go_crypto_tls_abi_internal_write"`
 	GoCryptoTlsAbiInternalWriteEx *ebpf.Program `ebpf:"go_crypto_tls_abi_internal_write_ex"`
-	SecuritySocketAccept          *ebpf.Program `ebpf:"security_socket_accept"`
 	SslRead                       *ebpf.Program `ebpf:"ssl_read"`
 	SslReadEx                     *ebpf.Program `ebpf:"ssl_read_ex"`
 	SslRetRead                    *ebpf.Program `ebpf:"ssl_ret_read"`
@@ -304,6 +303,7 @@ type tracerNoSniffPrograms struct {
 	SysExitRead                   *ebpf.Program `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.Program `ebpf:"sys_exit_write"`
 	SyscallAccept4                *ebpf.Program `ebpf:"syscall__accept4"`
+	SyscallAccept4Ret             *ebpf.Program `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.Program `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.Program `ebpf:"tcp_recvmsg"`
 	TcpSendmsg                    *ebpf.Program `ebpf:"tcp_sendmsg"`
@@ -320,7 +320,6 @@ func (p *tracerNoSniffPrograms) Close() error {
 		p.GoCryptoTlsAbiInternalReadEx,
 		p.GoCryptoTlsAbiInternalWrite,
 		p.GoCryptoTlsAbiInternalWriteEx,
-		p.SecuritySocketAccept,
 		p.SslRead,
 		p.SslReadEx,
 		p.SslRetRead,
@@ -338,6 +337,7 @@ func (p *tracerNoSniffPrograms) Close() error {
 		p.SysExitRead,
 		p.SysExitWrite,
 		p.SyscallAccept4,
+		p.SyscallAccept4Ret,
 		p.TcpConnect,
 		p.TcpRecvmsg,
 		p.TcpSendmsg,


### PR DESCRIPTION
`security_socket_accept` is not supported for M1 arm64 (https://github.com/kubeshark/worker/issues/223)