### PR TITLE
Syscalls replace security socket accept

### DIFF
--- a/bpf/events.c
+++ b/bpf/events.c
@@ -108,7 +108,7 @@ void BPF_KRETPROBE(syscall__accept4_ret) {
 }
 
 SEC("kretprobe/do_accept")
-void BPF_KPROBE(syscall__accept4) {
+void BPF_KRETPROBE(do_accept) {
     if (capture_disabled())
         return;
 

--- a/tcp_kprobe_hooks.go
+++ b/tcp_kprobe_hooks.go
@@ -33,7 +33,7 @@ func (s *tcpKprobeHooks) installTcpKprobeHooks(bpfObjects *tracerObjects) error 
 
 	s.accept, err = link.Kretprobe("sys_accept4", bpfObjects.SyscallAccept4Ret, nil)
 
-	s.accept4, err = link.Kprobe("security_socket_accept", bpfObjects.SyscallAccept4, nil)
+	s.accept4, err = link.Kretprobe("do_accept", bpfObjects.DoAccept, nil)
 	if err != nil {
 		return errors.Wrap(err, 0)
 	}

--- a/tcp_kprobe_hooks.go
+++ b/tcp_kprobe_hooks.go
@@ -32,6 +32,9 @@ func (s *tcpKprobeHooks) installTcpKprobeHooks(bpfObjects *tracerObjects) error 
 	}
 
 	s.accept, err = link.Kretprobe("sys_accept4", bpfObjects.SyscallAccept4Ret, nil)
+	if err != nil {
+		return errors.Wrap(err, 0)
+	}
 
 	s.accept4, err = link.Kretprobe("do_accept", bpfObjects.DoAccept, nil)
 	if err != nil {

--- a/tracer46_bpfel_x86.go
+++ b/tracer46_bpfel_x86.go
@@ -132,6 +132,7 @@ type tracer46Specs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type tracer46ProgramSpecs struct {
+	DoAccept                      *ebpf.ProgramSpec `ebpf:"do_accept"`
 	FilterEgressPackets           *ebpf.ProgramSpec `ebpf:"filter_egress_packets"`
 	FilterIngressPackets          *ebpf.ProgramSpec `ebpf:"filter_ingress_packets"`
 	GoCryptoTlsAbi0Read           *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi0_read"`
@@ -160,7 +161,6 @@ type tracer46ProgramSpecs struct {
 	SysExitConnect                *ebpf.ProgramSpec `ebpf:"sys_exit_connect"`
 	SysExitRead                   *ebpf.ProgramSpec `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.ProgramSpec `ebpf:"sys_exit_write"`
-	SyscallAccept4                *ebpf.ProgramSpec `ebpf:"syscall__accept4"`
 	SyscallAccept4Ret             *ebpf.ProgramSpec `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.ProgramSpec `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.ProgramSpec `ebpf:"tcp_recvmsg"`
@@ -282,6 +282,7 @@ func (m *tracer46Maps) Close() error {
 //
 // It can be passed to loadTracer46Objects or ebpf.CollectionSpec.LoadAndAssign.
 type tracer46Programs struct {
+	DoAccept                      *ebpf.Program `ebpf:"do_accept"`
 	FilterEgressPackets           *ebpf.Program `ebpf:"filter_egress_packets"`
 	FilterIngressPackets          *ebpf.Program `ebpf:"filter_ingress_packets"`
 	GoCryptoTlsAbi0Read           *ebpf.Program `ebpf:"go_crypto_tls_abi0_read"`
@@ -310,7 +311,6 @@ type tracer46Programs struct {
 	SysExitConnect                *ebpf.Program `ebpf:"sys_exit_connect"`
 	SysExitRead                   *ebpf.Program `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.Program `ebpf:"sys_exit_write"`
-	SyscallAccept4                *ebpf.Program `ebpf:"syscall__accept4"`
 	SyscallAccept4Ret             *ebpf.Program `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.Program `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.Program `ebpf:"tcp_recvmsg"`
@@ -320,6 +320,7 @@ type tracer46Programs struct {
 
 func (p *tracer46Programs) Close() error {
 	return _Tracer46Close(
+		p.DoAccept,
 		p.FilterEgressPackets,
 		p.FilterIngressPackets,
 		p.GoCryptoTlsAbi0Read,
@@ -348,7 +349,6 @@ func (p *tracer46Programs) Close() error {
 		p.SysExitConnect,
 		p.SysExitRead,
 		p.SysExitWrite,
-		p.SyscallAccept4,
 		p.SyscallAccept4Ret,
 		p.TcpConnect,
 		p.TcpRecvmsg,

--- a/tracer_bpfel_x86.go
+++ b/tracer_bpfel_x86.go
@@ -132,6 +132,7 @@ type tracerSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type tracerProgramSpecs struct {
+	DoAccept                      *ebpf.ProgramSpec `ebpf:"do_accept"`
 	FilterEgressPackets           *ebpf.ProgramSpec `ebpf:"filter_egress_packets"`
 	FilterIngressPackets          *ebpf.ProgramSpec `ebpf:"filter_ingress_packets"`
 	GoCryptoTlsAbi0Read           *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi0_read"`
@@ -160,7 +161,6 @@ type tracerProgramSpecs struct {
 	SysExitConnect                *ebpf.ProgramSpec `ebpf:"sys_exit_connect"`
 	SysExitRead                   *ebpf.ProgramSpec `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.ProgramSpec `ebpf:"sys_exit_write"`
-	SyscallAccept4                *ebpf.ProgramSpec `ebpf:"syscall__accept4"`
 	SyscallAccept4Ret             *ebpf.ProgramSpec `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.ProgramSpec `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.ProgramSpec `ebpf:"tcp_recvmsg"`
@@ -282,6 +282,7 @@ func (m *tracerMaps) Close() error {
 //
 // It can be passed to loadTracerObjects or ebpf.CollectionSpec.LoadAndAssign.
 type tracerPrograms struct {
+	DoAccept                      *ebpf.Program `ebpf:"do_accept"`
 	FilterEgressPackets           *ebpf.Program `ebpf:"filter_egress_packets"`
 	FilterIngressPackets          *ebpf.Program `ebpf:"filter_ingress_packets"`
 	GoCryptoTlsAbi0Read           *ebpf.Program `ebpf:"go_crypto_tls_abi0_read"`
@@ -310,7 +311,6 @@ type tracerPrograms struct {
 	SysExitConnect                *ebpf.Program `ebpf:"sys_exit_connect"`
 	SysExitRead                   *ebpf.Program `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.Program `ebpf:"sys_exit_write"`
-	SyscallAccept4                *ebpf.Program `ebpf:"syscall__accept4"`
 	SyscallAccept4Ret             *ebpf.Program `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.Program `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.Program `ebpf:"tcp_recvmsg"`
@@ -320,6 +320,7 @@ type tracerPrograms struct {
 
 func (p *tracerPrograms) Close() error {
 	return _TracerClose(
+		p.DoAccept,
 		p.FilterEgressPackets,
 		p.FilterIngressPackets,
 		p.GoCryptoTlsAbi0Read,
@@ -348,7 +349,6 @@ func (p *tracerPrograms) Close() error {
 		p.SysExitConnect,
 		p.SysExitRead,
 		p.SysExitWrite,
-		p.SyscallAccept4,
 		p.SyscallAccept4Ret,
 		p.TcpConnect,
 		p.TcpRecvmsg,

--- a/tracernosniff_bpfel_x86.go
+++ b/tracernosniff_bpfel_x86.go
@@ -132,6 +132,7 @@ type tracerNoSniffSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type tracerNoSniffProgramSpecs struct {
+	DoAccept                      *ebpf.ProgramSpec `ebpf:"do_accept"`
 	GoCryptoTlsAbi0Read           *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi0_read"`
 	GoCryptoTlsAbi0ReadEx         *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi0_read_ex"`
 	GoCryptoTlsAbi0Write          *ebpf.ProgramSpec `ebpf:"go_crypto_tls_abi0_write"`
@@ -156,7 +157,6 @@ type tracerNoSniffProgramSpecs struct {
 	SysExitConnect                *ebpf.ProgramSpec `ebpf:"sys_exit_connect"`
 	SysExitRead                   *ebpf.ProgramSpec `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.ProgramSpec `ebpf:"sys_exit_write"`
-	SyscallAccept4                *ebpf.ProgramSpec `ebpf:"syscall__accept4"`
 	SyscallAccept4Ret             *ebpf.ProgramSpec `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.ProgramSpec `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.ProgramSpec `ebpf:"tcp_recvmsg"`
@@ -278,6 +278,7 @@ func (m *tracerNoSniffMaps) Close() error {
 //
 // It can be passed to loadTracerNoSniffObjects or ebpf.CollectionSpec.LoadAndAssign.
 type tracerNoSniffPrograms struct {
+	DoAccept                      *ebpf.Program `ebpf:"do_accept"`
 	GoCryptoTlsAbi0Read           *ebpf.Program `ebpf:"go_crypto_tls_abi0_read"`
 	GoCryptoTlsAbi0ReadEx         *ebpf.Program `ebpf:"go_crypto_tls_abi0_read_ex"`
 	GoCryptoTlsAbi0Write          *ebpf.Program `ebpf:"go_crypto_tls_abi0_write"`
@@ -302,7 +303,6 @@ type tracerNoSniffPrograms struct {
 	SysExitConnect                *ebpf.Program `ebpf:"sys_exit_connect"`
 	SysExitRead                   *ebpf.Program `ebpf:"sys_exit_read"`
 	SysExitWrite                  *ebpf.Program `ebpf:"sys_exit_write"`
-	SyscallAccept4                *ebpf.Program `ebpf:"syscall__accept4"`
 	SyscallAccept4Ret             *ebpf.Program `ebpf:"syscall__accept4_ret"`
 	TcpConnect                    *ebpf.Program `ebpf:"tcp_connect"`
 	TcpRecvmsg                    *ebpf.Program `ebpf:"tcp_recvmsg"`
@@ -312,6 +312,7 @@ type tracerNoSniffPrograms struct {
 
 func (p *tracerNoSniffPrograms) Close() error {
 	return _TracerNoSniffClose(
+		p.DoAccept,
 		p.GoCryptoTlsAbi0Read,
 		p.GoCryptoTlsAbi0ReadEx,
 		p.GoCryptoTlsAbi0Write,
@@ -336,7 +337,6 @@ func (p *tracerNoSniffPrograms) Close() error {
 		p.SysExitConnect,
 		p.SysExitRead,
 		p.SysExitWrite,
-		p.SyscallAccept4,
 		p.SyscallAccept4Ret,
 		p.TcpConnect,
 		p.TcpRecvmsg,


### PR DESCRIPTION
Replace `security_socket_accept` with `do_accept` to support MAC M1