### PR TITLE
Add command line parameter to disable TLS log

### DIFF
--- a/bpf_logger.go
+++ b/bpf_logger.go
@@ -29,11 +29,14 @@ type logMessage struct {
 }
 
 type bpfLogger struct {
-	logReader *perf.Reader
+	logDisabled bool
+	logReader   *perf.Reader
 }
 
-func newBpfLogger(bpfObjects *tracerObjects, bufferSize int) (p *bpfLogger, err error) {
-	p = &bpfLogger{}
+func newBpfLogger(bpfObjects *tracerObjects, bufferSize int, logDisabled bool) (p *bpfLogger, err error) {
+	p = &bpfLogger{
+		logDisabled: logDisabled,
+	}
 
 	p.logReader, err = perf.NewReader(bpfObjects.LogBuffer, bufferSize)
 
@@ -64,6 +67,9 @@ func (p *bpfLogger) poll() {
 			return
 		}
 
+		if p.logDisabled {
+			continue
+		}
 		if record.LostSamples != 0 {
 			log.Info().Msg(fmt.Sprintf("Log buffer is full, dropped %d logs", record.LostSamples))
 			continue

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var globCbuf = flag.Int("cbuf", 0, fmt.Sprintf("Keep last N packets in circular 
 
 var disableEbpfCapture = flag.Bool("disable-ebpf", false, "Disable capture packet via eBPF")
 var enableSyscallEvents = flag.Bool("enable-syscall", false, "Enable syscall events processing")
+var disableTlsLog = flag.Bool("disable-tls-log", false, "Disable tls logging")
 
 type sslListArray []string
 

--- a/tracer.go
+++ b/tracer.go
@@ -197,7 +197,7 @@ func (t *Tracer) Init(
 
 	t.sslHooksStructs = make([]sslHooks, 0)
 
-	t.bpfLogger, err = newBpfLogger(&t.bpfObjects, logBufferSize)
+	t.bpfLogger, err = newBpfLogger(&t.bpfObjects, logBufferSize, *disableTlsLog)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
New command line parameter `-disable-tls-log` added to disable logging from eBPF code