### PR TITLE
Set sentry release with current version

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/kubeshark/tracer/misc"
 	"github.com/kubeshark/tracer/pkg/kubernetes"
+	"github.com/kubeshark/tracer/pkg/version"
 	"github.com/kubeshark/tracer/server"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -22,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/kubeshark/tracer/pkg/health"
+	"github.com/kubeshark/tracer/pkg/version"
 )
 
 const (
@@ -66,6 +68,7 @@ func main() {
 		// of transactions for tracing.
 		// We recommend adjusting this value in production,
 		TracesSampleRate: 1.0,
+		Release:          version.Ver,
 	}); err != nil {
 		log.Error().Err(err).Msg("Sentry initialization failed:")
 	} else {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/kubeshark/tracer/pkg/health"
-	"github.com/kubeshark/tracer/pkg/version"
 )
 
 const (

--- a/pkg/version/consts.go
+++ b/pkg/version/consts.go
@@ -1,0 +1,8 @@
+package version
+
+var (
+	Ver            = "0.0.1"
+	Branch         = "develop"
+	GitCommitHash  = "" // this var is overridden using ldflags in makefile when building
+	BuildTimestamp = "" // this var is overridden using ldflags in makefile when building
+)


### PR DESCRIPTION
Towards https://github.com/kubeshark/hub/issues/168

Proper version is set as part of https://github.com/kubeshark/worker/pull/270 