### PR TITLE
Align latest eBPF code for M1

### DIFF
--- a/bpf/file_probes.c
+++ b/bpf/file_probes.c
@@ -179,6 +179,7 @@ static __always_inline void find_cgroup_fs(void* ctx, const char* name) {
     }
 }
 
+/*
 static __always_inline void do_sys_open_helper_enter(void* ctx, int num, const char* filename, __u64 flags) {
     char buf[256];
     bpf_probe_read_user(buf, 256, filename);
@@ -228,6 +229,7 @@ int sys_exit_openat2(exit_sys_ctx* ctx) {
     do_sys_open_helper_exit(ctx);
     return 0;
 }
+*/
 
 SEC("kprobe/security_file_open")
 int BPF_KPROBE(security_file_open)

--- a/bpf/file_probes.c
+++ b/bpf/file_probes.c
@@ -369,6 +369,7 @@ int BPF_KPROBE(do_mkdirat_ret)
     return 0;
 }
 
+/*
 SEC("kprobe/security_path_mkdir")
 int BPF_KPROBE(security_path_mkdir)
 {
@@ -384,6 +385,7 @@ int BPF_KPROBE(security_path_mkdir)
 
     return 0;
 }
+*/
 
 SEC("kprobe/vfs_rmdir")
 int BPF_KPROBE(vfs_rmdir)

--- a/bpf/file_probes.c
+++ b/bpf/file_probes.c
@@ -179,58 +179,6 @@ static __always_inline void find_cgroup_fs(void* ctx, const char* name) {
     }
 }
 
-/*
-static __always_inline void do_sys_open_helper_enter(void* ctx, int num, const char* filename, __u64 flags) {
-    char buf[256];
-    bpf_probe_read_user(buf, 256, filename);
-    __u64 cgroup_id = compat_get_current_cgroup_id(NULL);
-    __u64 pid = tracer_get_current_pid_tgid() >> 32;
-
-    DEBUG_FILE_PROBE("ENTER n: %d cgid: %d pid: %d create: %d(%d) filename: %s", num, cgroup_id, pid, (flags & O_CREAT) ? 1 : 0, flags, buf);
-    return;
-}
-
-static __always_inline void do_sys_open_helper_exit(exit_sys_ctx* ctx) {
-    return;
-}
-
-SEC("tracepoint/syscalls/sys_enter_open")
-int sys_enter_open(enter_sys_open_ctx* ctx) {
-    do_sys_open_helper_enter(ctx, 1, ctx->filename, ctx->flags);
-    return 0;
-}
-
-SEC("tracepoint/syscalls/sys_exit_open")
-int sys_exit_open(exit_sys_ctx* ctx) {
-    do_sys_open_helper_exit(ctx);
-    return 0;
-}
-
-SEC("tracepoint/syscalls/sys_enter_openat")
-int sys_enter_openat(enter_sys_openat_ctx* ctx) {
-    do_sys_open_helper_enter(ctx, 2, ctx->filename, ctx->flags);
-    return 0;
-}
-
-SEC("tracepoint/syscalls/sys_exit_openat")
-int sys_exit_openat(exit_sys_ctx* ctx) {
-    do_sys_open_helper_exit(ctx);
-    return 0;
-}
-
-SEC("tracepoint/syscalls/sys_enter_openat2")
-int sys_enter_openat2(enter_sys_openat2_ctx* ctx) {
-    do_sys_open_helper_enter(ctx, 3, ctx->filename, 0);
-    return 0;
-}
-
-SEC("tracepoint/syscalls/sys_exit_openat2")
-int sys_exit_openat2(exit_sys_ctx* ctx) {
-    do_sys_open_helper_exit(ctx);
-    return 0;
-}
-*/
-
 SEC("kprobe/security_file_open")
 int BPF_KPROBE(security_file_open)
 {
@@ -369,7 +317,6 @@ int BPF_KPROBE(do_mkdirat_ret)
     return 0;
 }
 
-/*
 SEC("kprobe/security_path_mkdir")
 int BPF_KPROBE(security_path_mkdir)
 {
@@ -385,7 +332,6 @@ int BPF_KPROBE(security_path_mkdir)
 
     return 0;
 }
-*/
 
 SEC("kprobe/vfs_rmdir")
 int BPF_KPROBE(vfs_rmdir)

--- a/bpf/packet_sniffer.c
+++ b/bpf/packet_sniffer.c
@@ -48,6 +48,9 @@ cgroup_skb/ingress hook│                                 │cgroup_skb/egress 
 #include "include/logger_messages.h"
 #include "include/common.h"
 
+
+const volatile __u64 DISABLE_EBPF_CAPTURE = 0;
+
 /*
     defining ENABLE_TRACE_PACKETS enables tracing into kernel cyclic buffer
     which can be fetched on a host system with `cat /sys/kernel/debug/tracing/trace_pipe`
@@ -77,7 +80,8 @@ static __always_inline int parse_packet(struct __sk_buff* skb, int is_tc, __u32*
 
 SEC("cgroup_skb/ingress")
 int filter_ingress_packets(struct __sk_buff* skb) {
-
+    if (DISABLE_EBPF_CAPTURE)
+        return 1;
     if (capture_disabled())
         return 1;
 
@@ -96,6 +100,8 @@ int filter_ingress_packets(struct __sk_buff* skb) {
 
 SEC("cgroup_skb/egress")
 int filter_egress_packets(struct __sk_buff* skb) {
+    if (DISABLE_EBPF_CAPTURE)
+        return 1;
 
     if (capture_disabled())
         return 1;
@@ -122,6 +128,8 @@ int filter_egress_packets(struct __sk_buff* skb) {
 SEC("tc/ingress")
 int packet_pull_ingress(struct __sk_buff* skb)
 {
+    if (DISABLE_EBPF_CAPTURE)
+        return 1;
     if (capture_disabled())
         return 1;
 
@@ -151,6 +159,8 @@ int packet_pull_ingress(struct __sk_buff* skb)
 SEC("tc/egress")
 int packet_pull_egress(struct __sk_buff* skb)
 {
+    if (DISABLE_EBPF_CAPTURE)
+        return 1;
     if (capture_disabled())
         return 1;
 

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -75,7 +75,7 @@ func programHelperExists(pt ebpf.ProgramType, helper asm.BuiltinFunc) uint64 {
 	return 0
 }
 
-func NewBpfObjects() (*BpfObjects, error) {
+func NewBpfObjects(disableEbpfCapture bool) (*BpfObjects, error) {
 	var err error
 
 	objs := BpfObjects{}
@@ -118,12 +118,18 @@ func NewBpfObjects() (*BpfObjects, error) {
 			bpfObjs: &TracerObjects{},
 		}
 
+		disableCapture := uint64(0)
+		if disableEbpfCapture {
+			disableCapture = 1
+		}
+
 		bpfConsts := map[string]uint64{
 			"KERNEL_VERSION": kernelVersionInt,
 			"TRACER_NS_INO":  hostProcIno,
 			//"HELPER_EXISTS_KPROBE_bpf_strncmp":          programHelperExists(ebpf.Kprobe, asm.FnStrncmp),
 			"CGROUP_V1": cgroupV1,
 			"HELPER_EXISTS_UPROBE_bpf_ktime_get_tai_ns": programHelperExists(ebpf.TracePoint, asm.FnKtimeGetTaiNs),
+			"DISABLE_EBPF_CAPTURE":                      disableCapture,
 		}
 
 		err = objects.loadBpfObjects(bpfConsts, bytes.NewReader(_TracerBytes))

--- a/pkg/hooks/syscall/syscall_hooks.go
+++ b/pkg/hooks/syscall/syscall_hooks.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cilium/ebpf/link"
 	"github.com/go-errors/errors"
 	"github.com/kubeshark/tracer/pkg/bpf"
+	"github.com/rs/zerolog/log"
 )
 
 type syscallHooks struct {
@@ -109,32 +110,6 @@ func (s *syscallHooks) installSyscallHooks(bpfObjects *bpf.TracerObjects) error 
 		return err
 	}
 
-	/*
-		if err = s.addTracepoint("syscalls", "sys_enter_open", bpfObjects.SysEnterOpen); err != nil {
-			return err
-		}
-
-		if err = s.addTracepoint("syscalls", "sys_exit_open", bpfObjects.SysExitOpen); err != nil {
-			return err
-		}
-
-		if err = s.addTracepoint("syscalls", "sys_enter_openat", bpfObjects.SysEnterOpenat); err != nil {
-			return err
-		}
-
-		if err = s.addTracepoint("syscalls", "sys_exit_openat", bpfObjects.SysExitOpenat); err != nil {
-			return err
-		}
-
-		if err = s.addTracepoint("syscalls", "sys_enter_openat2", bpfObjects.SysEnterOpenat2); err != nil {
-			return err
-		}
-
-		if err = s.addTracepoint("syscalls", "sys_exit_openat2", bpfObjects.SysExitOpenat2); err != nil {
-			return err
-		}
-	*/
-
 	if err = s.addKprobe("security_file_open", bpfObjects.SecurityFileOpen); err != nil {
 		return err
 	}
@@ -167,11 +142,9 @@ func (s *syscallHooks) installSyscallHooks(bpfObjects *bpf.TracerObjects) error 
 		return err
 	}
 
-	/*
-		if err = s.addKprobe("security_path_mkdir", bpfObjects.SecurityPathMkdir); err != nil {
-			return err
-		}
-	*/
+	if err = s.addKprobe("security_path_mkdir", bpfObjects.SecurityPathMkdir); err != nil {
+		log.Warn().Err(err).Msg("security_path_mkdir can not be attached. Probably system is running on incomatible kernel")
+	}
 
 	if err = s.addRawTracepoint("sched_process_fork", bpfObjects.SchedProcessFork); err != nil {
 		return err

--- a/pkg/hooks/syscall/syscall_hooks.go
+++ b/pkg/hooks/syscall/syscall_hooks.go
@@ -9,38 +9,6 @@ import (
 
 type syscallHooks struct {
 	links []link.Link
-
-	/*
-		sysEnterRead     link.Link
-		sysEnterWrite    link.Link
-		sysEnterRecvfrom link.Link
-		sysEnterSendto   link.Link
-		sysExitRead      link.Link
-		sysExitWrite     link.Link
-		sysEnterAccept4  link.Link
-		sysExitAccept4   link.Link
-		sysEnterAccept   link.Link
-		sysExitAccept    link.Link
-		sysEnterConnect  link.Link
-		sysExitConnect   link.Link
-		sysEnterOpen     link.Link
-		sysExitOpen      link.Link
-		sysEnterOpenAt   link.Link
-		sysExitOpenAt    link.Link
-		sysEnterOpenAt2  link.Link
-		sysExitOpenAt2   link.Link
-
-		sysSecurityFileOpen    link.Link
-		sysSecurityInodeUnlink link.Link
-		sysSecurityInodeRename link.Link
-
-		sysVfsCreate         link.Link
-		sysVfsRename         link.Link
-		sysDoMkdirAt         link.Link
-		sysDoMkdirAtRet      link.Link
-		sysVfsRmDir          link.Link
-		sysSecurityPathMkdir link.Link
-	*/
 }
 
 func (s *syscallHooks) addTracepoint(group, name string, program *ebpf.Program) error {
@@ -141,29 +109,31 @@ func (s *syscallHooks) installSyscallHooks(bpfObjects *bpf.TracerObjects) error 
 		return err
 	}
 
-	if err = s.addTracepoint("syscalls", "sys_enter_open", bpfObjects.SysEnterOpen); err != nil {
-		return err
-	}
+	/*
+		if err = s.addTracepoint("syscalls", "sys_enter_open", bpfObjects.SysEnterOpen); err != nil {
+			return err
+		}
 
-	if err = s.addTracepoint("syscalls", "sys_exit_open", bpfObjects.SysExitOpen); err != nil {
-		return err
-	}
+		if err = s.addTracepoint("syscalls", "sys_exit_open", bpfObjects.SysExitOpen); err != nil {
+			return err
+		}
 
-	if err = s.addTracepoint("syscalls", "sys_enter_openat", bpfObjects.SysEnterOpenat); err != nil {
-		return err
-	}
+		if err = s.addTracepoint("syscalls", "sys_enter_openat", bpfObjects.SysEnterOpenat); err != nil {
+			return err
+		}
 
-	if err = s.addTracepoint("syscalls", "sys_exit_openat", bpfObjects.SysExitOpenat); err != nil {
-		return err
-	}
+		if err = s.addTracepoint("syscalls", "sys_exit_openat", bpfObjects.SysExitOpenat); err != nil {
+			return err
+		}
 
-	if err = s.addTracepoint("syscalls", "sys_enter_openat2", bpfObjects.SysEnterOpenat2); err != nil {
-		return err
-	}
+		if err = s.addTracepoint("syscalls", "sys_enter_openat2", bpfObjects.SysEnterOpenat2); err != nil {
+			return err
+		}
 
-	if err = s.addTracepoint("syscalls", "sys_exit_openat2", bpfObjects.SysExitOpenat2); err != nil {
-		return err
-	}
+		if err = s.addTracepoint("syscalls", "sys_exit_openat2", bpfObjects.SysExitOpenat2); err != nil {
+			return err
+		}
+	*/
 
 	if err = s.addKprobe("security_file_open", bpfObjects.SecurityFileOpen); err != nil {
 		return err

--- a/pkg/hooks/syscall/syscall_hooks.go
+++ b/pkg/hooks/syscall/syscall_hooks.go
@@ -167,9 +167,11 @@ func (s *syscallHooks) installSyscallHooks(bpfObjects *bpf.TracerObjects) error 
 		return err
 	}
 
-	if err = s.addKprobe("security_path_mkdir", bpfObjects.SecurityPathMkdir); err != nil {
-		return err
-	}
+	/*
+		if err = s.addKprobe("security_path_mkdir", bpfObjects.SecurityPathMkdir); err != nil {
+			return err
+		}
+	*/
 
 	if err = s.addRawTracepoint("sched_process_fork", bpfObjects.SchedProcessFork); err != nil {
 		return err

--- a/tracer.go
+++ b/tracer.go
@@ -53,7 +53,7 @@ func (t *Tracer) Init(
 		return err
 	}
 
-	t.bpfObjects, err = bpf.NewBpfObjects()
+	t.bpfObjects, err = bpf.NewBpfObjects(*disableEbpfCapture)
 	if err != nil {
 		return fmt.Errorf("creating bpf failed: %v", err)
 	}


### PR DESCRIPTION
resolves https://github.com/kubeshark/tracer/issues/98

* remove empty eBPF programs
* disable packets capturing code in case of `-disable-ebpf` is given
* optional `security_path_mkdir` eBPF hook attaching