### PR TITLE
Create ssl entry in ssl_pending call

### DIFF
--- a/bpf/openssl_uprobes.c
+++ b/bpf/openssl_uprobes.c
@@ -154,3 +154,9 @@ SEC("uretprobe/ssl_read_ex")
 void BPF_KPROBE(ssl_ret_read_ex) {
 	ssl_uretprobe(ctx, &openssl_read_context, FLAGS_IS_READ_BIT);
 }
+
+SEC("uprobe/ssl_pending")
+void BPF_KPROBE(ssl_pending, void* ssl) {
+	ssl_uprobe(ctx, ssl, 0, 0, &openssl_read_context, 0);
+}
+


### PR DESCRIPTION
Add uprobe to ssl_pending in order to create the entry in the ssl map for future ssl_read calls.