### PR TITLE
New option for cgroup V1 capture. Fix proceesPath resolution in minikube

### DIFF
--- a/bpf/events.c
+++ b/bpf/events.c
@@ -48,8 +48,8 @@ void BPF_KPROBE(tcp_connect) {
         .cgroup_id = cgroup_id,
         .pid = get_task_pid(task),
         .parent_pid = get_task_pid(get_parent_task(task)),
-        .host_pid = BPF_CORE_READ(task, tgid),
-        .host_parent_pid = get_parent_task_pid(task),
+        .host_pid = tracer_get_current_pid_tgid()>>32,
+        .host_parent_pid = tracer_get_task_pid_tgid(0, get_parent_task(task)) >>32,
         .inode_id = inode,
     };
 
@@ -108,8 +108,8 @@ void BPF_KRETPROBE(syscall__accept4_ret) {
         .cgroup_id = cgroup_id,
         .pid = get_task_pid(task),
         .parent_pid = get_task_pid(get_parent_task(task)),
-        .host_pid = BPF_CORE_READ(task, tgid),
-        .host_parent_pid = get_parent_task_pid(task),
+        .host_pid = tracer_get_current_pid_tgid()>>32,
+        .host_parent_pid = tracer_get_task_pid_tgid(0, get_parent_task(task)) >>32,
         .inode_id = inode,
     };
 
@@ -209,8 +209,8 @@ void BPF_KPROBE(tcp_close) {
         .cgroup_id = cgroup_id,
         .pid = get_task_pid(task),
         .parent_pid = get_task_pid(get_parent_task(task)),
-        .host_pid = BPF_CORE_READ(task, tgid),
-        .host_parent_pid = get_parent_task_pid(task),
+        .host_pid = tracer_get_current_pid_tgid()>>32,
+        .host_parent_pid = tracer_get_task_pid_tgid(0, get_parent_task(task)) >>32,
         .inode_id = inode,
     };
 

--- a/bpf/include/common.h
+++ b/bpf/include/common.h
@@ -16,6 +16,7 @@ const volatile __u64 TRACER_NS_INO = 0;
 const volatile __u64 KERNEL_VERSION = 0;
 const volatile __u64 CGROUP_V1 = 0;
 const volatile __u64 HELPER_EXISTS_UPROBE_bpf_ktime_get_tai_ns = 0;
+const volatile __u64 PREFER_CGROUP_V1_EBPF_CAPTURE = 0;
 
 static int add_address_to_chunk(struct pt_regs* ctx, struct tls_chunk* chunk, __u64 id, __u32 fd, struct ssl_info* info);
 static void send_chunk_part(struct pt_regs* ctx, uintptr_t buffer, __u64 id, struct tls_chunk* chunk, int start, int end);

--- a/bpf/packet_sniffer.c
+++ b/bpf/packet_sniffer.c
@@ -91,7 +91,7 @@ static __always_inline int filter_packets(struct __sk_buff *skb, void *cgrpctxma
         return 1;
 
     __u64 cgroup_id = 0;
-    if (CGROUP_V1)
+    if (CGROUP_V1 || PREFER_CGROUP_V1_EBPF_CAPTURE)
     {
         cgroup_id = get_packet_cgroup(skb, cgrpctxmap);
     }

--- a/bpf/packet_sniffer_v1.c
+++ b/bpf/packet_sniffer_v1.c
@@ -447,7 +447,7 @@ int BPF_KPROBE(security_socket_sendmsg)
 SEC("kprobe/security_sk_clone")
 int BPF_KPROBE(security_sk_clone)
 {
-    if (!CGROUP_V1)
+    if (!CGROUP_V1 && !PREFER_CGROUP_V1_EBPF_CAPTURE)
         return 0;
     struct sock *osock = (void *)PT_REGS_PARM1(ctx);
     struct sock *nsock = (void *)PT_REGS_PARM2(ctx);

--- a/main.go
+++ b/main.go
@@ -45,10 +45,12 @@ var initBPF = flag.Bool("init-bpf", false, "Use to initialize bpf filesystem. Co
 var disableEbpfCapture = flag.Bool("disable-ebpf", false, "Disable capture packet via eBPF")
 var disableTlsLog = flag.Bool("disable-tls-log", false, "Disable tls logging")
 
+var preferCgroupV1Capture = flag.Bool("ebpf1", false, "On systems with Cgroup V2 use Cgroup V1 method for packet capturing")
+
 var tracer *Tracer
 
 func main() {
-	()
+	flag.Parse()
 
 	// Set log level
 	var level zerolog.Level

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -85,7 +85,7 @@ func programHelperExists(pt ebpf.ProgramType, helper asm.BuiltinFunc) uint64 {
 	return 0
 }
 
-func NewBpfObjects(disableEbpfCapture bool) (*BpfObjects, error) {
+func NewBpfObjects(disableEbpfCapture, preferCgroupV1 bool) (*BpfObjects, error) {
 	var err error
 
 	objs := BpfObjects{}
@@ -159,11 +159,17 @@ func NewBpfObjects(disableEbpfCapture bool) (*BpfObjects, error) {
 			disableCapture = 1
 		}
 
+		preferCgroupV1Capture := uint64(0)
+		if preferCgroupV1 {
+			preferCgroupV1Capture = 1
+		}
+
 		bpfConsts := map[string]uint64{
 			"KERNEL_VERSION": kernelVersionInt,
 			"TRACER_NS_INO":  hostProcIno,
 			//"HELPER_EXISTS_KPROBE_bpf_strncmp":          programHelperExists(ebpf.Kprobe, asm.FnStrncmp),
-			"CGROUP_V1": cgroupV1,
+			"CGROUP_V1":                                 cgroupV1,
+			"PREFER_CGROUP_V1_EBPF_CAPTURE":             preferCgroupV1Capture,
 			"HELPER_EXISTS_UPROBE_bpf_ktime_get_tai_ns": programHelperExists(ebpf.TracePoint, asm.FnKtimeGetTaiNs),
 			"DISABLE_EBPF_CAPTURE":                      disableCapture,
 		}

--- a/tracer.go
+++ b/tracer.go
@@ -64,7 +64,7 @@ func (t *Tracer) Init(
 		return fmt.Errorf("cgroups controller create failed")
 	}
 
-	t.bpfObjects, err = bpf.NewBpfObjects(*disableEbpfCapture)
+	t.bpfObjects, err = bpf.NewBpfObjects(*disableEbpfCapture, *preferCgroupV1Capture)
 	if err != nil {
 		return fmt.Errorf("creating bpf failed: %v", err)
 	}
@@ -224,7 +224,7 @@ func initBPFSubsystem() {
 		}
 	}
 
-	_, err := bpf.NewBpfObjects(false)
+	_, err := bpf.NewBpfObjects(false, false)
 	if err != nil {
 		log.Error().Err(err).Msg("create objects failed")
 	}


### PR DESCRIPTION
resolves https://github.com/kubeshark/worker/issues/441

* `-ebpf1` option can be given to intercept packets according cgroup V1 algorithm in cgroup V2 systems
* `processPath` resolution fixed for docker-in-docker clusters like minikube
