### PR TITLE
Enabled IPv6 non-TLS packet processing

### DIFF
--- a/bpf/packet_sniffer.c
+++ b/bpf/packet_sniffer.c
@@ -262,20 +262,6 @@ static __always_inline int filter_packets(struct __sk_buff *skb,
     return 1;
   }
 
-  struct save_packet_args save_args = {
-      .skb = skb,
-      .cgroup_id = cgroup_id,
-      .direction = side,
-      .src_port =
-          (side == PACKET_DIRECTION_RECEIVED ? skb->remote_port >> 16
-                                             : bpf_htons(skb->local_port)),
-      .dst_port =
-          (side == PACKET_DIRECTION_RECEIVED ? bpf_htons(skb->local_port)
-                                             : skb->remote_port >> 16),
-      .transportHdr = transportHdr,
-      .transportOffset = transportOffset,
-  };
-
   struct pkt_sniffer_ctx ctx = {
       .skb = skb,
       .cgroup_id = cgroup_id,
@@ -336,7 +322,7 @@ static __noinline void _save_packet(struct pkt_sniffer_ctx *ctx)
     __u8 ip_version = 0;
 
     if (bpf_skb_load_bytes(skb, 0, &ip_version, 1) < 0) {
-        return 1;
+        return;
     }
 
     ip_version = (ip_version >> 4) & 0xF;

--- a/bpf/packet_sniffer.c
+++ b/bpf/packet_sniffer.c
@@ -54,6 +54,7 @@ struct pkt
     __u32 counter;
     __u16 num;
     __u16 last;
+    __u16 ip_hdr_type;
     __u8 direction;
     unsigned char buf[PKT_PART_LEN];
 };
@@ -89,41 +90,134 @@ BPF_PERF_OUTPUT_LARGE(pkts_buffer);
 // #define ENABLE_TRACE_PACKETS
 
 #ifdef ENABLE_TRACE_PACKETS
-#define TRACE_PACKET(NAME, IS_CGROUP, LOCAL_IP, REMOTE_IP, LOCAL_PORT, REMOTE_PORT, CGROUP_ID)              \
-    bpf_printk("PKT " NAME " skb: %p len: %d ret: %d", skb, (IS_CGROUP ? (skb->len + 14) : skb->len), ret); \
-    bpf_printk("PKT " NAME " cgroup: %d cookie:0x%x", CGROUP_ID, bpf_get_socket_cookie(skb));               \
-    bpf_printk("PKT " NAME " ip_local: %pi4 ip_remote: %pi4", &(LOCAL_IP), &(REMOTE_IP));                   \
-    {                                                                                                       \
-        __u32 __port_local = bpf_ntohl(LOCAL_PORT);                                                         \
-        __u32 __port_remote = bpf_ntohl(REMOTE_PORT);                                                       \
-        bpf_printk("PKT " NAME " port_local: 0x%x port_remote: 0x%x", __port_local, __port_remote);         \
-    }                                                                                                       \
-    bpf_printk("PKT " NAME " ip_src: %pi4 ip_dst:%pi4", &(src_ip), &(dst_ip));                              \
-    {                                                                                                       \
-        __u32 __src_port = bpf_ntohl(src_port);                                                             \
-        __u32 __dst_port = bpf_ntohl(dst_port);                                                             \
-        bpf_printk("PKT " NAME " port_src: 0x%x port_dst: 0x%x", __src_port, __dst_port);                   \
-    }
-#define TRACE_PACKET_SENT(NAME) \
-    bpf_printk("PKT " NAME " sent");
+#define TRACE_PACKET_IPV4(NAME, IS_CGROUP, LOCAL_IP, REMOTE_IP, LOCAL_PORT,    \
+                          REMOTE_PORT, CGROUP_ID)                              \
+  bpf_printk("PKT " NAME " skb: %p len: %d ret: %d", skb,                      \
+             (IS_CGROUP ? (skb->len + 14) : skb->len), ret);                   \
+  bpf_printk("PKT " NAME " cgroup: %d cookie:0x%x", CGROUP_ID,                 \
+             bpf_get_socket_cookie(skb));                                      \
+  bpf_printk("PKT " NAME " ip_local: %pi4 ip_remote: %pi4", &(LOCAL_IP),       \
+             &(REMOTE_IP));                                                    \
+  {                                                                            \
+    __u32 __port_local = bpf_ntohl(LOCAL_PORT);                                \
+    __u32 __port_remote = bpf_ntohl(REMOTE_PORT);                              \
+    bpf_printk("PKT " NAME " port_local: 0x%x port_remote: 0x%x",              \
+               __port_local, __port_remote);                                   \
+  }                                                                            \
+  bpf_printk("PKT " NAME " ip_src: %pi4 ip_dst:%pi4", &(src_ip), &(dst_ip));   \
+  {                                                                            \
+    __u32 __src_port = bpf_ntohl(src_port);                                    \
+    __u32 __dst_port = bpf_ntohl(dst_port);                                    \
+    bpf_printk("PKT " NAME " port_src: 0x%x port_dst: 0x%x", __src_port,       \
+               __dst_port);                                                    \
+  }
+
+#define PRINT_IPV6_ADDR(NAME, ADDR)                                           \
+  bpf_printk(NAME ": %x:%x:%x:%x",                                           \
+             bpf_ntohl(ADDR[0]), bpf_ntohl(ADDR[1]),                          \
+             bpf_ntohl(ADDR[2]), bpf_ntohl(ADDR[3]));
+#define PRINT_IPV6_ADDR_STRUCT(NAME, ADDR)                                      \
+   __u16 addr_parts[8];                                                        \
+    __builtin_memcpy(addr_parts, &ADDR, sizeof(addr_parts));                    \
+    bpf_printk(NAME ": %x:%x:%x:%x",                                           \
+               bpf_ntohs(addr_parts[0]),                                        \
+               bpf_ntohs(addr_parts[1]),                                        \
+               bpf_ntohs(addr_parts[2]),                                        \
+               bpf_ntohs(addr_parts[3]));                                       \
+    bpf_printk(NAME ": %x:%x:%x:%x",                                           \
+               bpf_ntohs(addr_parts[4]),                                        \
+               bpf_ntohs(addr_parts[5]),                                        \
+               bpf_ntohs(addr_parts[6]),                                        \
+               bpf_ntohs(addr_parts[7]));                                       
+#define TRACE_PACKET_IPV6(NAME, IS_CGROUP, LOCAL_IP6, REMOTE_IP6, LOCAL_PORT,    \
+                          REMOTE_PORT, CGROUP_ID)                              \
+  bpf_printk("PKT " NAME " [IPv6] skb: %p len: %d", skb,                       \
+             (IS_CGROUP ? (skb->len + 14) : skb->len));                        \
+  bpf_printk("PKT " NAME " [IPv6] cgroup: %d cookie:0x%x", CGROUP_ID,          \
+             bpf_get_socket_cookie(skb));                                      \
+  PRINT_IPV6_ADDR("ip_local", LOCAL_IP6);                                      \
+  PRINT_IPV6_ADDR("ip_remote", REMOTE_IP6);                                    \
+  {                                                                            \
+    __u32 __port_local = bpf_ntohl(LOCAL_PORT);                                \
+    __u32 __port_remote = bpf_ntohl(REMOTE_PORT);                              \
+    bpf_printk("PKT " NAME " port_local: 0x%x port_remote: 0x%x",              \
+               __port_local, __port_remote);                                   \
+  }                                                                            \
+  PRINT_IPV6_ADDR_STRUCT("ip_src", src_ip6);                                          \
+  PRINT_IPV6_ADDR_STRUCT("ip_dst", dst_ip6);                                          \
+  {                                                                            \
+    __u32 __src_port = bpf_ntohl(src_port);                                    \
+    __u32 __dst_port = bpf_ntohl(dst_port);                                    \
+    bpf_printk("PKT " NAME " port_src: 0x%x port_dst: 0x%x", __src_port,       \
+               __dst_port);                                                    \
+  }
+#define TRACE_PACKET_SENT(NAME) bpf_printk("PKT " NAME " sent");
 #else
-#define TRACE_PACKET(NAME, IS_CGROUP, LOCAL_IP, REMOTE_IP, LOCAL_PORT, REMOTE_PORT, CGROUP_ID) \
-    src_ip;                                                                                    \
-    dst_ip;                                                                                    \
-    src_port;                                                                                  \
-    dst_port;
+#define TRACE_PACKET_IPV4(NAME, IS_CGROUP, LOCAL_IP, REMOTE_IP, LOCAL_PORT,    \
+                          REMOTE_PORT, CGROUP_ID)
+#define TRACE_PACKET_IPV6(NAME, IS_CGROUP, LOCAL_IP6, REMOTE_IP6, LOCAL_PORT,  \
+                          REMOTE_PORT, CGROUP_ID)
 #define TRACE_PACKET_SENT(NAME)
 #endif
 
 #define ETH_P_IP 0x0800
+#define ETH_P_IPV6 0x86DD
+#define IPV6_EXT_MAX_CHAIN 4
+#ifndef IPPROTO_HOPOPTS
+#define IPPROTO_HOPOPTS   0
+#endif
 
-static __always_inline void save_packet(struct __sk_buff *skb, __u32 rewrite_ip_src, __u16 rewrite_port_src, __u32 rewrite_ip_dst, __u16 rewrite_port_dst, __u64 cgroup_id, __u8 direction);
-static __always_inline int parse_packet(struct __sk_buff *skb, int is_tc, __u32 *src_ip4, __u16 *src_port, __u32 *dst_ip4, __u16 *dst_port, __u8 *ipp);
+#ifndef IPPROTO_ROUTING
+#define IPPROTO_ROUTING   43
+#endif
+
+#ifndef IPPROTO_FRAGMENT
+#define IPPROTO_FRAGMENT  44
+#endif
+
+#ifndef IPPROTO_DSTOPTS
+#define IPPROTO_DSTOPTS   60
+#endif
+
+#ifndef IPPROTO_MH
+#define IPPROTO_MH        135
+#endif
+
+struct save_packet_args {
+    struct __sk_buff *skb;
+    __u64 cgroup_id;
+    __u8 direction;
+    __u8 transportHdr;
+    __u8 transportOffset;
+    __u16 src_port;
+    __u16 dst_port;
+
+    union {
+        struct {
+            __u32 src_ip;
+            __u32 dst_ip;
+        } ipv4;
+
+        struct {
+            struct in6_addr src_ip6;
+            struct in6_addr dst_ip6;
+        } ipv6;
+    };
+};
+
+static __always_inline void save_packet(struct save_packet_args *args);
+static __always_inline int parse_packet(struct __sk_buff *skb,
+                                        __u32 *src_ip4, __u16 *src_port,
+                                        __u32 *dst_ip4, __u16 *dst_port,
+                                        __u8 *ipp, struct in6_addr *src_ip6,
+                                        struct in6_addr *dst_ip6,
+                                        __u32 *transportOffset);
 
 static __always_inline int filter_packets(struct __sk_buff *skb, void *cgrpctxmap, __u8 side)
 {
-    if (program_disabled(PROGRAM_DOMAIN_CAPTURE_PLAIN))
+    if (program_disabled(PROGRAM_DOMAIN_CAPTURE_PLAIN)) {
         return 1;
+    }
 
     __u64 cgroup_id = 0;
     if (CGROUP_V1 || PREFER_CGROUP_V1_EBPF_CAPTURE)
@@ -144,21 +238,71 @@ static __always_inline int filter_packets(struct __sk_buff *skb, void *cgrpctxma
     __u16 src_port = 0;
     __u32 dst_ip = 0;
     __u16 dst_port = 0;
-    int ret = parse_packet(skb, 0, &src_ip, &src_port, &dst_ip, &dst_port, NULL);
+    struct in6_addr src_ip6 = {0};
+    struct in6_addr dst_ip6 = {0};
+    __u8 transportHdr = 0;
+    __u32 transportOffset = 0;
+    int ret = -1;
+
+    __u8 ip_version = 0;
+
+    if (bpf_skb_load_bytes(skb, 0, &ip_version, 1) < 0) {
+        return 1;
+    }
+
+    ip_version = (ip_version >> 4) & 0xF;
+
+    if (ip_version == 6) {
+        ret = parse_packet(skb, &src_ip, &src_port, &dst_ip, &dst_port, &transportHdr, &src_ip6, &dst_ip6, &transportOffset);
+    } else {
+        ret = parse_packet(skb, &src_ip, &src_port, &dst_ip, &dst_port, NULL, &src_ip6, &dst_ip6, NULL);
+    }
     if (!ret)
     {
         return 1;
     }
 
+    struct save_packet_args save_args = {
+        .skb = skb,
+        .cgroup_id = cgroup_id,
+        .direction = side,
+        .src_port = ( side == PACKET_DIRECTION_RECEIVED ? skb->remote_port>>16 : bpf_htons(skb->local_port)),
+        .dst_port = ( side == PACKET_DIRECTION_RECEIVED ? bpf_htons(skb->local_port) : skb->remote_port>>16),
+        .transportHdr = transportHdr,
+        .transportOffset = transportOffset,
+    };
+
     if (side == PACKET_DIRECTION_RECEIVED)
     {
-        TRACE_PACKET("cg/in", true, skb->local_ip4, skb->remote_ip4, skb->local_port & 0xffff, skb->remote_port & 0xffff, cgroup_id);
-        save_packet(skb, src_ip, skb->remote_port >> 16, dst_ip, bpf_htons(skb->local_port), cgroup_id, side);
+        if (src_ip) {
+            // IPv4
+            TRACE_PACKET_IPV4("cg/in", true, skb->local_ip4, skb->remote_ip4, skb->local_port & 0xffff, skb->remote_port & 0xffff, cgroup_id);
+            save_args.ipv4.src_ip = src_ip;
+            save_args.ipv4.dst_ip = dst_ip;
+            save_packet(&save_args);
+        } else {
+            // IPv6
+            TRACE_PACKET_IPV6("cg/in", true, skb->local_ip6, skb->remote_ip6, skb->local_port & 0xffff, skb->remote_port & 0xffff, cgroup_id);
+            save_args.ipv6.src_ip6 = src_ip6;
+            save_args.ipv6.dst_ip6 = dst_ip6;
+            save_packet(&save_args);    
+        }
     }
     else
     {
-        TRACE_PACKET("cg/out", true, skb->local_ip4, skb->remote_ip4, skb->local_port & 0xffff, skb->remote_port & 0xffff, cgroup_id);
-        save_packet(skb, src_ip, bpf_htons(skb->local_port), dst_ip, skb->remote_port >> 16, cgroup_id, side);
+        if (src_ip) {
+            // IPv4
+            TRACE_PACKET_IPV4("cg/out", true, skb->local_ip4, skb->remote_ip4, skb->local_port & 0xffff, skb->remote_port & 0xffff, cgroup_id);
+            save_args.ipv4.src_ip = src_ip;
+            save_args.ipv4.dst_ip = dst_ip;
+            save_packet(&save_args);
+        } else {
+            // IPv6
+            TRACE_PACKET_IPV6("cg/out", true, skb->local_ip6, skb->remote_ip6, skb->local_port & 0xffff, skb->remote_port & 0xffff, cgroup_id);
+            save_args.ipv6.src_ip6 = src_ip6;
+            save_args.ipv6.dst_ip6 = dst_ip6;
+            save_packet(&save_args);    
+        }
     }
 
     return 1;
@@ -176,29 +320,42 @@ int filter_egress_packets(struct __sk_buff *skb)
     return filter_packets(skb, &cgrpctxmap_eg, PACKET_DIRECTION_SENT);
 }
 
-struct pkt_sniffer_ctx
-{
-    struct __sk_buff *skb;
-    __u32 rewrite_ip_src;
-    __u16 rewrite_port_src;
-    __u32 rewrite_ip_dst;
-    __u16 rewrite_port_dst;
-    __u64 cgroup_id;
-    __u8 direction;
+struct pkt_sniffer_ctx {
+    struct __sk_buff *skb;       
+    __u32 rewrite_ip_src;          
+    __u16 rewrite_port_src;       
+    __u32 rewrite_ip_dst;         
+    __u16 rewrite_port_dst;        
+    struct in6_addr rewrite_ip6_src; 
+    struct in6_addr rewrite_ip6_dst; 
+    __u64 cgroup_id;               
+    __u8 direction;      
+    __u8 transportHdrType;          
+    __u32 transportOffset;
 };
 
 static __noinline void _save_packet(struct pkt_sniffer_ctx *ctx);
-static __always_inline void save_packet(struct __sk_buff *skb, __u32 rewrite_ip_src, __u16 rewrite_port_src, __u32 rewrite_ip_dst, __u16 rewrite_port_dst, __u64 cgroup_id, __u8 direction)
+static __always_inline void save_packet(struct save_packet_args *args)
 {
     struct pkt_sniffer_ctx ctx = {
-        .skb = skb,
-        .rewrite_ip_src = rewrite_ip_src,
-        .rewrite_port_src = rewrite_port_src,
-        .rewrite_ip_dst = rewrite_ip_dst,
-        .rewrite_port_dst = rewrite_port_dst,
-        .cgroup_id = cgroup_id,
-        .direction = direction,
+        .skb = args->skb,
+        .cgroup_id = args->cgroup_id,
+        .direction = args->direction,
+        .transportHdrType = args->transportHdr,
+        .transportOffset = args->transportOffset,
+        .rewrite_port_src = args->src_port,
+        .rewrite_port_dst = args->dst_port,
     };
+
+
+    if (args->skb->protocol == bpf_htons(ETH_P_IPV6)) {
+        __builtin_memcpy(&ctx.rewrite_ip6_src, &args->ipv6.src_ip6, sizeof(struct in6_addr));
+        __builtin_memcpy(&ctx.rewrite_ip6_dst, &args->ipv6.dst_ip6, sizeof(struct in6_addr));
+    } else {
+        ctx.rewrite_ip_src = args->ipv4.src_ip;
+        ctx.rewrite_ip_dst = args->ipv4.dst_ip;
+    }
+
     return _save_packet(&ctx);
 }
 
@@ -209,6 +366,8 @@ static __noinline void _save_packet(struct pkt_sniffer_ctx *ctx)
     __u16 rewrite_port_src = ctx->rewrite_port_src;
     __u32 rewrite_ip_dst = ctx->rewrite_ip_dst;
     __u16 rewrite_port_dst = ctx->rewrite_port_dst;
+    struct in6_addr *rewrite_ip6_src = &ctx->rewrite_ip6_src;
+    struct in6_addr *rewrite_ip6_dst = &ctx->rewrite_ip6_dst;
     __u64 cgroup_id = ctx->cgroup_id;
     __u8 direction = ctx->direction;
     int zero = 0;
@@ -247,8 +406,7 @@ static __noinline void _save_packet(struct pkt_sniffer_ctx *ctx)
     bpf_spin_unlock(&pkt_id_ptr->lock);
 
     // send initial chunk before the first packet
-    if (unlikely(packet_id == 0))
-    {
+    if (unlikely(packet_id == 0)) {
         if (bpf_perf_event_output(skb, &pkts_buffer, BPF_F_CURRENT_CPU, p, 0))
         {
             log_error(skb, LOG_ERROR_PKT_SNIFFER, 11, 0l, 0l);
@@ -262,6 +420,7 @@ static __noinline void _save_packet(struct pkt_sniffer_ctx *ctx)
     p->num = 0;
     p->len = 0;
     p->last = 0;
+    p->ip_hdr_type = bpf_ntohs(ctx->skb->protocol);
 
 #pragma unroll
     for (__u32 i = 0; (i < PKT_MAX_LEN / PKT_PART_LEN) && p->counter; i++)
@@ -304,20 +463,47 @@ static __noinline void _save_packet(struct pkt_sniffer_ctx *ctx)
                 return;
             }
         }
+        if (ctx->skb->protocol == bpf_htons(ETH_P_IPV6)) {
+            struct ipv6hdr *ip6 = (struct ipv6hdr *)p->buf;
+            if (rewrite_ip6_src)
+                __builtin_memcpy(&ip6->saddr, rewrite_ip6_src, sizeof(struct in6_addr));
+            if (rewrite_ip6_dst)
+                __builtin_memcpy(&ip6->daddr, rewrite_ip6_dst, sizeof(struct in6_addr));
 
-        struct iphdr *ip = (struct iphdr *)p->buf;
-        if (rewrite_ip_src)
-            ip->saddr = rewrite_ip_src;
-        if (rewrite_ip_dst)
-            ip->daddr = rewrite_ip_dst;
-        if (ip->protocol == IPPROTO_TCP || ip->protocol == IPPROTO_UDP)
-        {
-            int hdrsize = ip->ihl * 4;
-            __u16 *src_dst = (__u16 *)(&p->buf[0] + hdrsize);
-            if (rewrite_port_src)
-                *src_dst = rewrite_port_src;
-            if (rewrite_port_dst)
-                *(src_dst + 1) = rewrite_port_dst;
+            if (ctx->transportHdrType == IPPROTO_TCP || ctx->transportHdrType == IPPROTO_UDP) {
+                if (ctx->transportOffset >= PKT_PART_LEN) {
+                    log_error(skb, LOG_ERROR_PKT_SNIFFER, 12, ctx->transportOffset, 0l);
+                    return;
+                }
+
+                void *transport_hdr = (void *)(&p->buf[ctx->transportOffset]);
+
+                if ((void *)transport_hdr + sizeof(struct tcphdr) > (void *)&p->buf[PKT_PART_LEN]) {
+                    log_error(skb, LOG_ERROR_PKT_SNIFFER, 13, ctx->transportOffset, 0l);
+                    return;
+                }
+
+                __u16 *src_dst = (__u16 *)transport_hdr;
+                if (rewrite_port_src)
+                    *src_dst = rewrite_port_src;
+                if (rewrite_port_dst)
+                    *(src_dst + 1) = rewrite_port_dst;
+            }
+        } else {
+            struct iphdr *ip = (struct iphdr *)p->buf;
+            if (rewrite_ip_src)
+                ip->saddr = rewrite_ip_src;
+            if (rewrite_ip_dst)
+                ip->daddr = rewrite_ip_dst;
+            if (ip->protocol == IPPROTO_TCP || ip->protocol == IPPROTO_UDP)
+            {
+                int hdrsize = ip->ihl * 4;
+                __u16 *src_dst = (__u16 *)(&p->buf[0] + hdrsize);
+                if (rewrite_port_src)
+                    *src_dst = rewrite_port_src;
+                if (rewrite_port_dst)
+                    *(src_dst + 1) = rewrite_port_dst;
+            }
         }
 
         if (bpf_perf_event_output(skb, &pkts_buffer, BPF_F_CURRENT_CPU, p, sizeof(struct pkt)))
@@ -332,89 +518,132 @@ static __noinline void _save_packet(struct pkt_sniffer_ctx *ctx)
   0 in case packet has TCP source or destination port equal to 443 - in this case packet is treated as TLS and not going to be processed
   not 0 in other cases
 */
-static __always_inline int parse_packet(struct __sk_buff *skb, int is_tc, __u32 *src_ip4, __u16 *src_port, __u32 *dst_ip4, __u16 *dst_port, __u8 *ipp)
-{
-    void *data = (void *)(long)skb->data;
-    void *data_end = (void *)(long)skb->data_end;
-    void *cursor = data;
+static __always_inline int parse_packet(struct __sk_buff *skb,
+                                        __u32 *src_ip4, __u16 *src_port,
+                                        __u32 *dst_ip4, __u16 *dst_port,
+                                        __u8 *ipp, struct in6_addr *src_ip6,
+                                        struct in6_addr *dst_ip6,
+                                        __u32 *transportOffset) {
+  void *data = (void *)(long)skb->data;
+  void *data_end = (void *)(long)skb->data_end;
+  void *cursor = data;
 
-    if (is_tc)
-    {
-        struct ethhdr *eth = (struct ethhdr *)cursor;
-        if (eth + 1 > (struct ethhdr *)data_end)
-            return 1;
+  __u8 ip_proto = 0;
+  if (skb->protocol == bpf_htons(ETH_P_IP)) {
 
-        cursor += sizeof(struct ethhdr);
+    struct iphdr *ip = (struct iphdr *)cursor;
+    if (ip + 1 > (struct iphdr *)data_end)
+      return 2;
+
+    if (src_ip4) {
+      *src_ip4 = ip->saddr;
+    }
+    if (dst_ip4) {
+      *dst_ip4 = ip->daddr;
     }
 
-    __u8 ip_proto = 0;
-    if (skb->protocol == bpf_htons(ETH_P_IP))
-    {
+    int hdrsize = ip->ihl * 4;
+    if (hdrsize < sizeof(struct iphdr))
+      return 3;
 
-        struct iphdr *ip = (struct iphdr *)cursor;
-        if (ip + 1 > (struct iphdr *)data_end)
-            return 2;
+    if ((void *)ip + hdrsize > data_end)
+      return 4;
 
-        if (src_ip4)
-        {
-            *src_ip4 = ip->saddr;
-        }
-        if (dst_ip4)
-        {
-            *dst_ip4 = ip->daddr;
-        }
-
-        int hdrsize = ip->ihl * 4;
-        if (hdrsize < sizeof(struct iphdr))
-            return 3;
-
-        if ((void *)ip + hdrsize > data_end)
-            return 4;
-
-        cursor += hdrsize;
-        ip_proto = ip->protocol;
-        if (ipp)
-        {
-            *ipp = ip_proto;
-        }
-
-        if (ip_proto == IPPROTO_TCP)
-        {
-            struct tcphdr *tcp = (struct tcphdr *)cursor;
-            if (tcp + 1 > (struct tcphdr *)data_end)
-                return 5;
-            if (src_port)
-            {
-                *src_port = tcp->source;
-            }
-            if (dst_port)
-            {
-                *dst_port = tcp->dest;
-            }
-
-            cursor += tcp->doff * 4;
-            if (tcp->dest == bpf_htons(443) || tcp->source == bpf_htons(443))
-            {
-                // skip only packets with tcp port 443 to support previous bpf filter
-                return 0;
-            }
-        }
-
-        if (ip_proto == IPPROTO_UDP)
-        {
-            struct udphdr *udp = (struct udphdr *)cursor;
-            if (udp + 1 > (struct udphdr *)data_end)
-                return 5;
-            if (src_port)
-            {
-                *src_port = udp->source;
-            }
-            if (dst_port)
-            {
-                *dst_port = udp->dest;
-            }
-        }
+    cursor += hdrsize;
+    ip_proto = ip->protocol;
+    if (ipp) {
+      *ipp = ip_proto;
+    }
+  } else {
+    struct ipv6hdr *ip6 = (struct ipv6hdr *)cursor;
+    if ((ip6 + 1 > (struct ipv6hdr *)data_end)) {
+      return 6;
     }
 
-    return 6;
+    if (src_ip6) {
+      __builtin_memcpy(src_ip6, &ip6->saddr, sizeof(struct in6_addr));
+    }
+
+    if (dst_ip6) {
+      __builtin_memcpy(dst_ip6, &ip6->daddr, sizeof(struct in6_addr));
+    }
+
+    ip_proto = ip6->nexthdr;
+    cursor += sizeof(struct ipv6hdr);
+
+#pragma unroll
+    for (int i = 0; i < IPV6_EXT_MAX_CHAIN; i++) {
+      struct ipv6_opt_hdr *hdr = (struct ipv6_opt_hdr *)cursor;
+
+      if (hdr + 1 > (struct ipv6_opt_hdr *)data_end)
+        return 7;
+
+      if (ip_proto == IPPROTO_TCP || ip_proto == IPPROTO_UDP ||
+          ip_proto == IPPROTO_ICMPV6) {
+        break; // Reached the transport layer
+      }
+
+      switch (ip_proto) {
+      case IPPROTO_HOPOPTS:
+      case IPPROTO_ROUTING:
+      case IPPROTO_DSTOPTS:
+      case IPPROTO_MH:
+        cursor += (hdr->hdrlen + 1) * 8;
+        break;
+      case IPPROTO_AH:
+        cursor += hdr->hdrlen * 4;
+        break;
+      case IPPROTO_FRAGMENT:
+        cursor += 8;
+        break;
+      default:
+        return 7;
+      }
+
+      if (cursor > data_end)
+        return 7;
+
+      ip_proto = hdr->nexthdr;
+    }
+
+    if (transportOffset) {
+        *transportOffset = cursor - data;
+    }
+
+    if (ipp) {
+      *ipp = ip_proto;
+    }
+  }
+
+  if (ip_proto == IPPROTO_TCP) {
+    struct tcphdr *tcp = (struct tcphdr *)cursor;
+    if (tcp + 1 > (struct tcphdr *)data_end)
+      return 5;
+    if (src_port) {
+      *src_port = tcp->source;
+    }
+    if (dst_port) {
+      *dst_port = tcp->dest;
+    }
+
+    cursor += tcp->doff * 4;
+    if (tcp->dest == bpf_htons(443) || tcp->source == bpf_htons(443)) {
+      // skip only packets with tcp port 443 to support previous bpf filter
+      return 0;
+    }
+  }
+
+  if (ip_proto == IPPROTO_UDP) {
+    struct udphdr *udp = (struct udphdr *)cursor;
+    if (udp + 1 > (struct udphdr *)data_end)
+      return 5;
+    if (src_port) {
+      *src_port = udp->source;
+    }
+    if (dst_port) {
+      *dst_port = udp->dest;
+    }
+  }
+
+  return 6;
 }


### PR DESCRIPTION
- add support for processing and saving IPv6 packets in packet filter
- update packets with the eth layer to IPv4 or IPv6 depending on the packet type in poller