### PR TITLE
Always capture packets for cgroup 0

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -140,10 +140,6 @@ func (t *Tracer) updateTargets(addPods, removePods []*v1.Pod, settings uint32) e
 	}
 
 	for _, pod := range removePods {
-		if t.packetFilter.DetachPod(string(pod.UID)) {
-			log.Info().Str("pod", pod.Name).Msg("Detached pod from cgroup:")
-		}
-
 		pInfo, ok := t.runningPods[pod.UID]
 		if !ok {
 			continue
@@ -184,13 +180,6 @@ func (t *Tracer) updateTargets(addPods, removePods []*v1.Pod, settings uint32) e
 					t.stats.TargetedCgroupsAdd++
 				}
 
-				if ok, err := t.packetFilter.AttachPod(string(pod.UID), cInfo.cgroupPath); err != nil {
-					log.Warn().Err(err).Uint64("Cgroup ID", cInfo.cgroupID).Str("Cgroup path", cInfo.cgroupPath).Str("pod", pod.Name).Msg("Attach pod to cgroup failed:")
-					_ = t.bpfObjects.BpfObjs.CgroupIds.Delete(cInfo.cgroupID)
-					continue
-				} else if ok {
-					log.Info().Str("pod", pod.Name).Msg("Attached pod to cgroup:")
-				}
 				t.eventsDiscoverer.TargetCgroup(cInfo.cgroupID)
 				log.Info().Str("Container ID", containerId).Uint64("Cgroup ID", cInfo.cgroupID).Msg("Cgroup has been targeted")
 			}


### PR DESCRIPTION
On systems with Cgroup V2 traffic always should go through `filter_ingress_packets
` and `filter_egress_packets` to make flow_stats work properly, despite actual pod targeting